### PR TITLE
Override latest Terraform version for greater granularity

### DIFF
--- a/image/actions.sh
+++ b/image/actions.sh
@@ -29,7 +29,11 @@ function detect-terraform-version() {
     echo "$TF_SWITCH_OUTPUT"
   else
     echo "Reading latest terraform version"
-    tfswitch "$(latest_terraform_version)"
+    if [[ "$INPUT_VERSION" == "" ]]; then
+      tfswitch "$(latest_terraform_version)"
+    else
+      tfswitch "$INPUT_VERSION"
+    fi
   fi
 }
 

--- a/image/tools/latest_terraform_version.py
+++ b/image/tools/latest_terraform_version.py
@@ -29,7 +29,7 @@ if __name__ == '__main__':
 def test_version():
     versions = get_versions()
     print(versions)
-    assert StrictVersion('0.12.28') in versions
+    assert StrictVersion('0.12.29') in versions
     assert StrictVersion('0.12.5') in versions
     assert StrictVersion('0.11.14') in versions
     assert StrictVersion('0.13.0') in versions

--- a/terraform-plan/action.yaml
+++ b/terraform-plan/action.yaml
@@ -22,6 +22,9 @@ inputs:
   var_file:
     description: Comma separated list of var file paths
     required: false
+  version:
+    description: Override Terraform latest version
+    required: false
   parallelism:
     description: Limit the number of concurrent operations
     required: false

--- a/terraform-version/action.yaml
+++ b/terraform-version/action.yaml
@@ -6,6 +6,9 @@ inputs:
   path:
     description: Path to the terraform configuration
     required: true
+  version:
+    description: Override Terraform latest version
+    required: false
 
 outputs:
   version:


### PR DESCRIPTION
We have decided to maintain a stable Terraform version internally, so I needed a way to be able to specify a specific release (0.12.29) instead of automatically upgrading the the latest (0.13.0 at this time). This change does just that. If this is concept is acceptable, I'll update the embedded documentation and identify any other actions that could use the same change.

Thanks for clean and easy to understand code!