### PR TITLE
Fix example workflow errors in triggers

### DIFF
--- a/example_workflows/create_plan.yaml
+++ b/example_workflows/create_plan.yaml
@@ -3,7 +3,7 @@ name: Create terraform plan
 on:
   pull_request:
     branches:
-      - !master
+      - "!master"
 
 jobs:
   plan:

--- a/example_workflows/validate.yaml
+++ b/example_workflows/validate.yaml
@@ -3,7 +3,7 @@ name: Validate changes
 on:
   push:
     branches:
-      - !master
+      - "!master"
 
 jobs:
   fmt-check:


### PR DESCRIPTION
I have noticed that `!master` branch in example workflow triggers produces an invalid YAML