### PR TITLE
WIP: Show the errors by enabling the -diff parameter

### DIFF
--- a/image/entrypoints/fmt-check.sh
+++ b/image/entrypoints/fmt-check.sh
@@ -6,7 +6,7 @@ debug
 setup
 
 EXIT_CODE=0
-for file in $(terraform fmt -recursive -no-color -check "$INPUT_PATH"); do
+for file in $(terraform fmt -recursive -no-color -check -diff "$INPUT_PATH"); do
     echo "::error file=$file::File is not in canonical format (terraform fmt)"
     EXIT_CODE=1
 done


### PR DESCRIPTION
When doing fmt it is extremely helpfull to see the fmt error output. That can be achieved by having `diff` parameter used in `terraform` command.