### PR TITLE
Switch to docker github actions for login, build and push actions

### DIFF
--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -13,20 +13,21 @@ jobs:
     name: Docker Images
     env:
       GITHUB_TOKEN: ${{ github.token }}
-      DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Registry login
-        run: |
-          echo $DOCKER_TOKEN | docker login --username danielflook --password-stdin
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          file: image/Dockerfile-base
+          context: image
+          push: true
+          tags: danielflook/terraform-github-actions-base:latest, danielflook/terraform-github-actions-base:$GITHUB_RUN_ID
 
-      - name: Base image
-        run: |
-          docker build --tag dflook/terraform-github-actions-base -f image/Dockerfile-base image
-
-          docker tag dflook/terraform-github-actions-base danielflook/terraform-github-actions-base:latest
-          docker push danielflook/terraform-github-actions-base:latest
-          docker tag dflook/terraform-github-actions-base danielflook/terraform-github-actions-base:$GITHUB_RUN_ID
-          docker push danielflook/terraform-github-actions-base:$GITHUB_RUN_ID
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,37 +9,53 @@ jobs:
     runs-on: ubuntu-latest
     name: Publish Docker Image
     env:
-      GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
       DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Registry login
-        run: |
-          echo $GITHUB_TOKEN | docker login ghcr.io -u dflook --password-stdin
-          echo $DOCKER_TOKEN | docker login --username danielflook --password-stdin
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Action image
-        run: |
-          docker build --tag dflook/terraform-github-actions-base -f image/Dockerfile-base image
+      - name: Build base image
+        id: docker_build_base
+        uses: docker/build-push-action@v2
+        with:
+          file: image/Dockerfile-base
+          context: image
+          push: false
+          tags: danielflook/terraform-github-actions-base:latest
 
-          RELEASE_TAG=$(cat $GITHUB_EVENT_PATH | jq -r  '.release.tag_name' $GITHUB_EVENT_PATH)
+      - name: Base image digest
+        run: echo ${{ steps.docker_build_base.outputs.digest }}
 
-          docker build --tag dflook/terraform-github-actions \
-            --label org.opencontainers.image.created="$(date '+%Y-%m-%dT%H:%M:%S%z')" \
-            --label org.opencontainers.image.source="https://github.com/${{ github.repository }}" \
-            --label org.opencontainers.image.revision="${{ github.sha }}" \
-            --label org.opencontainers.image.version="$RELEASE_TAG" \
-            --label vcs-ref="$RELEASE_TAG" \
-            --label build="$GITHUB_RUN_ID" \
-            image
+      - name: Build release image
+        id: docker_build_release
+        uses: docker/build-push-action@v2
+        with:
+          file: Dockerfile
+          context: image
+          push: true
+          labels: |
+            org.opencontainers.image.created="$(date '+%Y-%m-%dT%H:%M:%S%z')"
+            org.opencontainers.image.source="https://github.com/${{ github.repository }}"
+            org.opencontainers.image.revision="${{ github.sha }}"
+            org.opencontainers.image.version="${{ github.event.release.tag_name }}"
+            vcs-ref="${{ github.event.release.tag_name }}"
+            build="$GITHUB_RUN_ID"
+          tags: |
+            ghcr.io/dflook/terraform-github-actions:${{ github.event.release.tag_name }}
+            danielflook/terraform-github-actions:${{ github.event.release.tag_name }}
 
-          docker tag dflook/terraform-github-actions ghcr.io/dflook/terraform-github-actions:$RELEASE_TAG
-          docker push ghcr.io/dflook/terraform-github-actions:$RELEASE_TAG
-
-          docker tag dflook/terraform-github-actions danielflook/terraform-github-actions:$RELEASE_TAG
-          docker push danielflook/terraform-github-actions:$RELEASE_TAG
+      - name: Release image digest
+        run: echo ${{ steps.docker_build_release.outputs.digest }}
 
   release_actions:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Hi @dflook,
This PR would help in moving to GitHub Actions for docker login, build and push.
You would need to setup/update your secrets to DOCKERHUB_USERNAME and DOCKERHUB_TOKEN.

Image digest parts are for information only, feel free to remove it if that's not useful after initial test

I have not tested this changes so please do test them.