### PR TITLE
fix: Output `variables` to Terraform Cloud compatible `.tfvars` file

### DIFF
--- a/image/actions.sh
+++ b/image/actions.sh
@@ -205,7 +205,7 @@ function set-plan-args() {
 
   if [[ -n "$INPUT_VARIABLES" ]]; then
     echo "$INPUT_VARIABLES" > /.terraform-variables.tfvars
-    echo "$INPUT_VARIABLES" > /.terraform-github-actions.auto.tfvars
+    echo "$INPUT_VARIABLES" > /zzz-terraform-github-actions.auto.tfvars
     PLAN_ARGS="$PLAN_ARGS -var-file=/.terraform-variables.tfvars"
   fi
 

--- a/image/actions.sh
+++ b/image/actions.sh
@@ -205,6 +205,7 @@ function set-plan-args() {
 
   if [[ -n "$INPUT_VARIABLES" ]]; then
     echo "$INPUT_VARIABLES" > /.terraform-variables.tfvars
+    echo "$INPUT_VARIABLES" > /.terraform-github-actions.auto.tfvars
     PLAN_ARGS="$PLAN_ARGS -var-file=/.terraform-variables.tfvars"
   fi
 


### PR DESCRIPTION
A fairly esoteric requirement, but I am using Terraform Cloud as a remote backend and because Terraform Cloud itself uses `-var-file` _and_ explicitly discards any other arguments, the `variables` input of this action does not currently work (impacts `apply`, `plan` etc.)

> Note: Remote runs do not use environment variables from your shell environment, and do not support specifying variables (or .tfvars files) as command line arguments. ~ [Variables in CLI-Driven Runs](https://www.terraform.io/docs/cloud/run/cli.html#variables-in-cli-driven-runs)

I'm not sure if there's a use-case where using `.auto.tfvars` is problematic and that is why `-var-file` has been used by this action, or if it's just a consequence of Terraform evolving to support multiple variable approaches over the years, so although the `-var-file` _could_ be removed without changing behaviour (if the Terraform documentation is accurate!) I've avoided any potential issues by leaving the current behaviour as-is and added one new `.auto.tfvars` file.

The `zzz-` prefix is because of the ordering of `auto.tfvars` files:

> If the same variable is assigned multiple values, Terraform uses the last value it finds, overriding any previous values. [...] Any *.auto.tfvars or *.auto.tfvars.json files, **processed in lexical order of their filenames**. ~ [Variable Definition Precedence](https://www.terraform.io/docs/language/values/variables.html#variable-definition-precedence)

Another option could be to simply rename `.terraform-variables.tfvars` to `zzz-...auto.tfvars` and use that parameter instead, but I'm not sure if anyone is relying on the `.terraform-variables.tfvars` filename! 