### PR TITLE
Fix ownership of files created in runner mounted directories

### DIFF
--- a/image/entrypoints/apply.sh
+++ b/image/entrypoints/apply.sh
@@ -31,8 +31,6 @@ function apply() {
     local APPLY_EXIT=${PIPESTATUS[0]}
     set -e
 
-    find "$INPUT_PATH" -regex '.*/zzzz-dflook-terraform-github-actions-[0-9]+\.auto\.tfvars' -delete
-
     if [[ $APPLY_EXIT -eq 0 ]]; then
         update_status "Plan applied in $(job_markdown_ref)"
     else
@@ -61,7 +59,6 @@ if [[ $PLAN_EXIT -eq 1 ]]; then
 fi
 
 if [[ $PLAN_EXIT -eq 1 ]]; then
-    find "$INPUT_PATH" -regex '.*/zzzz-dflook-terraform-github-actions-[0-9]+\.auto\.tfvars' -delete
     cat "$STEP_TMP_DIR/terraform_plan.stderr"
 
     update_status "Error applying plan in $(job_markdown_ref)"
@@ -77,13 +74,11 @@ if [[ "$INPUT_AUTO_APPROVE" == "true" || $PLAN_EXIT -eq 0 ]]; then
 else
 
     if [[ "$GITHUB_EVENT_NAME" != "push" && "$GITHUB_EVENT_NAME" != "pull_request" && "$GITHUB_EVENT_NAME" != "issue_comment" && "$GITHUB_EVENT_NAME" != "pull_request_review_comment" && "$GITHUB_EVENT_NAME" != "pull_request_target" && "$GITHUB_EVENT_NAME" != "pull_request_review" ]]; then
-        find "$INPUT_PATH" -regex '.*/zzzz-dflook-terraform-github-actions-[0-9]+\.auto\.tfvars' -delete
         echo "Could not fetch plan from the PR - $GITHUB_EVENT_NAME event does not relate to a pull request. You can generate and apply a plan automatically by setting the auto_approve input to 'true'"
         exit 1
     fi
 
     if [[ ! -v GITHUB_TOKEN ]]; then
-        find "$INPUT_PATH" -regex '.*/zzzz-dflook-terraform-github-actions-[0-9]+\.auto\.tfvars' -delete
         echo "GITHUB_TOKEN environment variable must be set to get plan approval from a PR"
         echo "Either set the GITHUB_TOKEN environment variable or automatically approve by setting the auto_approve input to 'true'"
         echo "See https://github.com/dflook/terraform-github-actions/ for details."
@@ -91,8 +86,6 @@ else
     fi
 
     if ! github_pr_comment get "$STEP_TMP_DIR/approved-plan.txt" 2>"$STEP_TMP_DIR/github_pr_comment.stderr"; then
-        find "$INPUT_PATH" -regex '.*/zzzz-dflook-terraform-github-actions-[0-9]+\.auto\.tfvars' -delete
-
         debug_file "$STEP_TMP_DIR/github_pr_comment.stderr"
         echo "Plan not found on PR"
         echo "Generate the plan first using the dflook/terraform-plan action. Alternatively set the auto_approve input to 'true'"
@@ -100,13 +93,13 @@ else
 
         set_output failure-reason plan-changed
         exit 1
+    else
+        debug_file "$STEP_TMP_DIR/github_pr_comment.stderr"
     fi
 
     if plan_cmp "$STEP_TMP_DIR/plan.txt" "$STEP_TMP_DIR/approved-plan.txt"; then
         apply
     else
-        find "$INPUT_PATH" -regex '.*/zzzz-dflook-terraform-github-actions-[0-9]+\.auto\.tfvars' -delete
-
         echo "Not applying the plan - it has changed from the plan on the PR"
         echo "The plan on the PR must be up to date. Alternatively, set the auto_approve input to 'true' to apply outdated plans"
         update_status "Plan not applied in $(job_markdown_ref) (Plan has changed)"

--- a/image/entrypoints/check.sh
+++ b/image/entrypoints/check.sh
@@ -21,7 +21,6 @@ if [[ $PLAN_EXIT -eq 1 ]]; then
         set-remote-plan-args
         PLAN_OUT=""
         plan
-        find "$INPUT_PATH" -regex '.*/zzzz-dflook-terraform-github-actions-[0-9]+\.auto\.tfvars' -delete
     fi
 fi
 

--- a/image/entrypoints/plan.sh
+++ b/image/entrypoints/plan.sh
@@ -23,7 +23,6 @@ if [[ $PLAN_EXIT -eq 1 ]]; then
         set-remote-plan-args
         PLAN_OUT=""
         plan
-        find "$INPUT_PATH" -regex '.*/zzzz-dflook-terraform-github-actions-[0-9]+\.auto\.tfvars' -delete
     fi
 fi
 
@@ -41,7 +40,10 @@ if [[ "$GITHUB_EVENT_NAME" == "pull_request" || "$GITHUB_EVENT_NAME" == "issue_c
             if ! STATUS="Failed to generate plan in $(job_markdown_ref)" github_pr_comment plan <"$STEP_TMP_DIR/terraform_plan.stderr" 2>"$STEP_TMP_DIR/github_pr_comment.stderr"; then
                 debug_file "$STEP_TMP_DIR/github_pr_comment.stderr"
                 exit 1
+            else
+                debug_file "$STEP_TMP_DIR/github_pr_comment.stderr"
             fi
+
         else
 
             if [[ $PLAN_EXIT -eq 0 ]]; then
@@ -53,6 +55,8 @@ if [[ "$GITHUB_EVENT_NAME" == "pull_request" || "$GITHUB_EVENT_NAME" == "issue_c
             if ! TF_CHANGES=$TF_CHANGES STATUS="Plan generated in $(job_markdown_ref)" github_pr_comment plan <"$STEP_TMP_DIR/plan.txt" 2>"$STEP_TMP_DIR/github_pr_comment.stderr"; then
                 debug_file "$STEP_TMP_DIR/github_pr_comment.stderr"
                 exit 1
+            else
+                debug_file "$STEP_TMP_DIR/github_pr_comment.stderr"
             fi
         fi
 

--- a/image/tools/github_pr_comment.py
+++ b/image/tools/github_pr_comment.py
@@ -18,6 +18,8 @@ github.headers['accept'] = 'application/vnd.github.v3+json'
 github_url = os.environ.get('GITHUB_SERVER_URL', 'https://github.com')
 github_api_url = os.environ.get('GITHUB_API_URL', 'https://api.github.com')
 
+job_tmp_dir = os.environ.get('JOB_TMP_DIR', '.')
+
 def github_api_request(method, *args, **kwargs):
     response = github.request(method, *args, **kwargs)
 
@@ -109,7 +111,7 @@ def current_user() -> str:
     token_hash = hashlib.sha256(os.environ["GITHUB_TOKEN"].encode()).hexdigest()
 
     try:
-        with open(f'.dflook-terraform/token-cache/{token_hash}') as f:
+        with open(os.path.join(job_tmp_dir, 'token-cache', token_hash)) as f:
             username = f.read()
             debug(f'GITHUB_TOKEN username: {username}')
             return username
@@ -128,8 +130,8 @@ def current_user() -> str:
         username = 'github-actions[bot]'
 
     try:
-        os.makedirs('.dflook-terraform/token-cache', exist_ok=True)
-        with open(f'.dflook-terraform/token-cache/{token_hash}', 'w') as f:
+        os.makedirs(os.path.join(job_tmp_dir, 'token-cache'), exist_ok=True)
+        with open(os.path.join(job_tmp_dir, 'token-cache', token_hash), 'w') as f:
             f.write(username)
     except Exception as e:
         debug(str(e))


### PR DESCRIPTION
As the container is run as root, it can cause issues when root owned files are leftover that the runner can't cleanup.
This would only affect self-hosted, non-ephemeral, non-root runners.