### PR TITLE
feat: add lock_during_plan input for terraform-plan

### DIFF
--- a/image/actions.sh
+++ b/image/actions.sh
@@ -211,6 +211,10 @@ function set-plan-args() {
         PLAN_ARGS="$PLAN_ARGS -var-file=$STEP_TMP_DIR/variables.tfvars"
     fi
 
+    if [[ -n "$INPUT_LOCK_DURING_PLAN" ]]; then
+        PLAN_ARGS="$PLAN_ARGS -lock=$INPUT_LOCK_DURING_PLAN"
+    fi
+
     export PLAN_ARGS
 }
 

--- a/terraform-plan/README.md
+++ b/terraform-plan/README.md
@@ -154,6 +154,13 @@ The [dflook/terraform-apply](https://github.com/dflook/terraform-github-actions/
   - Type: string
   - Optional
 
+* `lock_during_plan`
+
+  The default is `true`, which locks the state during plan.
+    - Type: string
+    - Optional
+    - Default: true
+
 ## Environment Variables
 
 * `GITHUB_TOKEN`

--- a/terraform-plan/action.yaml
+++ b/terraform-plan/action.yaml
@@ -39,6 +39,10 @@ inputs:
     description: Add the plan to a GitHub PR
     required: false
     default: true
+  lock_during_plan:
+    description: Specify whether the state should be locked during terraform plan
+    required: false
+    default: true
 
 outputs:
   changes:


### PR DESCRIPTION
Added the `lock_during_plan` optional input.