### PR TITLE
Add target to plan, add replace to plan & apply

### DIFF
--- a/.github/workflows/test-target-replace.yaml
+++ b/.github/workflows/test-target-replace.yaml
@@ -213,3 +213,261 @@ jobs:
             echo "::error:: Replacement has not affected targeted resources"
             exit 1
           fi
+
+  remote_plan_targeting:
+    runs-on: ubuntu-latest
+    name: Remote Plan targeting
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup remote backend
+        run: |
+          cat >tests/target/backend.tf <<EOF
+          terraform {
+            backend "remote" {
+              organization = "flooktech"
+
+              workspaces {
+                prefix = "github-actions-replace-"
+              }
+            }
+          }
+          EOF
+
+      - name: Create test workspace
+        uses: ./terraform-new-workspace
+        with:
+          path: tests/target
+          workspace: ${{ github.head_ref }}
+          backend_config: "token=${{ secrets.TF_API_TOKEN }}"
+
+      - name: Plan with no changes in targets
+        uses: ./terraform-plan
+        id: plan
+        with:
+          label: No targeted changes
+          path: tests/target
+          target: |
+            random_string.notpresent
+          variables: |
+            length = 5
+          workspace: ${{ github.head_ref }}
+          backend_config: "token=${{ secrets.TF_API_TOKEN }}"
+
+      - name: Verify outputs
+        run: |
+          if [[ "${{ steps.plan.outputs.changes }}" != "false" ]]; then
+            echo "::error:: Should not be any changes with this targeted plan"
+            exit 1
+          fi
+
+      - name: Plan targeted change
+        uses: ./terraform-plan
+        id: plan-first-change
+        with:
+          path: tests/target
+          target: |
+            random_string.count[0]
+          variables: |
+            length = 5
+          workspace: ${{ github.head_ref }}
+          backend_config: "token=${{ secrets.TF_API_TOKEN }}"
+
+      - name: Verify outputs
+        run: |
+          if [[ "${{ steps.plan-first-change.outputs.changes }}" != "true" ]]; then
+            echo "::error:: Targeted plan should have changes"
+            exit 1
+          fi
+
+      - name: Apply targeted change
+        uses: ./terraform-apply
+        id: apply-first-change
+        with:
+          path: tests/target
+          target: |
+            random_string.count[0]
+          variables: |
+            length = 5
+          workspace: ${{ github.head_ref }}
+          backend_config: "token=${{ secrets.TF_API_TOKEN }}"
+
+      - name: Verify outputs
+        run: |
+          if [[ "${{ steps.apply-first-change.outputs.count }}" == "" ]]; then
+            echo "::error:: output count not set correctly"
+            exit 1
+          fi
+
+      - name: Plan targeted change
+        uses: ./terraform-plan
+        id: plan-second-change
+        with:
+          path: tests/target
+          target: |
+            random_string.foreach["hello"]
+          variables: |
+            length = 6
+          workspace: ${{ github.head_ref }}
+          backend_config: "token=${{ secrets.TF_API_TOKEN }}"
+
+      - name: Verify outputs
+        run: |
+          if [[ "${{ steps.plan-second-change.outputs.changes }}" != "true" ]]; then
+            echo "::error:: Targeted plan should have changes"
+            exit 1
+          fi
+
+      - name: Apply targeted change
+        uses: ./terraform-apply
+        id: apply-second-change
+        with:
+          path: tests/target
+          target: |
+            random_string.foreach["hello"]
+          variables: |
+            length = 6
+          workspace: ${{ github.head_ref }}
+          backend_config: "token=${{ secrets.TF_API_TOKEN }}"
+
+      - name: Verify outputs
+        run: |
+          if [[ "${{ steps.apply-second-change.outputs.foreach }}" == "" ]]; then
+            echo "::error:: output foreach not set correctly"
+            exit 1
+          fi
+
+          if [[ "${{ steps.apply-second-change.outputs.count }}" != "${{ steps.apply-first-change.outputs.count }}" ]]; then
+            echo "::error:: Targeted change has affected untargeted resources"
+            exit 1
+          fi
+
+      - name: Auto Apply targeted change
+        uses: ./terraform-apply
+        id: apply-third-change
+        with:
+          path: tests/target
+          target: |
+            random_string.count[0]
+            random_string.foreach["hello"]
+          variables: |
+            length = 10
+          auto_approve: true
+          workspace: ${{ github.head_ref }}
+          backend_config: "token=${{ secrets.TF_API_TOKEN }}"
+
+      - name: Verify outputs
+        run: |
+          if [[ "${{ steps.apply-third-change.outputs.count }}" == "${{ steps.apply-second-change.outputs.count }}" ]]; then
+            echo "::error:: Targeted change has not affected targeted resources"
+            exit 1
+          fi
+
+          if [[ "${{ steps.apply-third-change.outputs.foreach }}" == "${{ steps.apply-second-change.outputs.foreach }}" ]]; then
+            echo "::error:: Targeted change has not affected targeted resources"
+            exit 1
+          fi
+
+      - name: Plan targeted replacement
+        uses: ./terraform-plan
+        id: plan-targeted-replacement
+        with:
+          path: tests/target
+          target: |
+            random_string.foreach["hello"]
+          replace: |
+            random_string.foreach["hello"]
+            random_string.count[0]
+          variables: |
+            length = 10
+          workspace: ${{ github.head_ref }}
+          backend_config: "token=${{ secrets.TF_API_TOKEN }}"
+
+      - name: Verify outputs
+        run: |
+          if [[ "${{ steps.plan-targeted-replacement.outputs.changes }}" != "true" ]]; then
+            echo "::error:: Targeted replacement should have changes"
+            exit 1
+          fi
+
+      - name: Apply targeted replacement
+        uses: ./terraform-apply
+        id: apply-targeted-replacement
+        with:
+          path: tests/target
+          target: |
+            random_string.foreach["hello"]
+          replace: |
+            random_string.foreach["hello"]
+            random_string.count[0]
+          variables: |
+            length = 10
+          workspace: ${{ github.head_ref }}
+          backend_config: "token=${{ secrets.TF_API_TOKEN }}"
+
+      - name: Verify outputs
+        run: |
+          if [[ "${{ steps.apply-targeted-replacement.outputs.count }}" != "${{ steps.apply-third-change.outputs.count }}" ]]; then
+            echo "::error:: Targeted replacement has affected non targeted resources"
+            exit 1
+          fi
+
+          if [[ "${{ steps.apply-targeted-replacement.outputs.foreach }}" == "${{ steps.apply-third-change.outputs.foreach }}" ]]; then
+            echo "::error:: Targeted replacement has not affected targeted resources"
+            exit 1
+          fi
+
+      - name: Plan replacement
+        uses: ./terraform-plan
+        id: plan-replacement
+        with:
+          path: tests/target
+          replace: |
+            random_string.foreach["hello"]
+            random_string.count[0]
+          variables: |
+            length = 10
+          workspace: ${{ github.head_ref }}
+          backend_config: "token=${{ secrets.TF_API_TOKEN }}"
+
+      - name: Verify outputs
+        run: |
+          if [[ "${{ steps.plan-replacement.outputs.changes }}" != "true" ]]; then
+            echo "::error:: Replacement should have changes"
+            exit 1
+          fi
+
+      - name: Apply replacement
+        uses: ./terraform-apply
+        id: apply-replacement
+        with:
+          path: tests/target
+          replace: |
+            random_string.foreach["hello"]
+            random_string.count[0]
+          variables: |
+            length = 10
+          workspace: ${{ github.head_ref }}
+          backend_config: "token=${{ secrets.TF_API_TOKEN }}"
+
+      - name: Verify outputs
+        run: |
+          if [[ "${{ steps.apply-replacement.outputs.count }}" == "${{ steps.apply-targeted-replacement.outputs.count }}" ]]; then
+            echo "::error:: Replacement has not affected targeted resources"
+            exit 1
+          fi
+
+          if [[ "${{ steps.apply-replacement.outputs.foreach }}" == "${{ steps.apply-targeted-replacement.outputs.foreach }}" ]]; then
+            echo "::error:: Replacement has not affected targeted resources"
+            exit 1
+          fi
+
+      - name: Destroy the workspace
+        uses: ./terraform-destroy-workspace
+        with:
+          path: tests/target
+          workspace: ${{ github.head_ref }}
+          variables: |
+            length = 10
+          backend_config: "token=${{ secrets.TF_API_TOKEN }}"

--- a/.github/workflows/test-target-replace.yaml
+++ b/.github/workflows/test-target-replace.yaml
@@ -1,0 +1,215 @@
+name: Test plan target and replace
+
+on: [pull_request]
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  plan_targeting:
+    runs-on: ubuntu-latest
+    name: Plan targeting
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Plan with no changes in targets
+        uses: ./terraform-plan
+        id: plan
+        with:
+          label: No targeted changes
+          path: tests/target
+          target: |
+            random_string.notpresent
+          variables: |
+            length = 5
+
+      - name: Verify outputs
+        run: |
+          if [[ "${{ steps.plan.outputs.changes }}" != "false" ]]; then
+            echo "::error:: Should not be any changes with this targeted plan"
+            exit 1
+          fi
+
+      - name: Plan targeted change
+        uses: ./terraform-plan
+        id: plan-first-change
+        with:
+          path: tests/target
+          target: |
+            random_string.count[0]
+          variables: |
+            length = 5
+
+      - name: Verify outputs
+        run: |
+          if [[ "${{ steps.plan-first-change.outputs.changes }}" != "true" ]]; then
+            echo "::error:: Targeted plan should have changes"
+            exit 1
+          fi
+
+      - name: Apply targeted change
+        uses: ./terraform-apply
+        id: apply-first-change
+        with:
+          path: tests/target
+          target: |
+            random_string.count[0]
+          variables: |
+            length = 5
+
+      - name: Verify outputs
+        run: |
+          if [[ "${{ steps.apply-first-change.outputs.count }}" == "" ]]; then
+            echo "::error:: output count not set correctly"
+            exit 1
+          fi
+
+      - name: Plan targeted change
+        uses: ./terraform-plan
+        id: plan-second-change
+        with:
+          path: tests/target
+          target: |
+            random_string.foreach["hello"]
+          variables: |
+            length = 6
+
+      - name: Verify outputs
+        run: |
+          if [[ "${{ steps.plan-second-change.outputs.changes }}" != "true" ]]; then
+            echo "::error:: Targeted plan should have changes"
+            exit 1
+          fi
+
+      - name: Apply targeted change
+        uses: ./terraform-apply
+        id: apply-second-change
+        with:
+          path: tests/target
+          target: |
+            random_string.foreach["hello"]
+          variables: |
+            length = 6
+
+      - name: Verify outputs
+        run: |
+          if [[ "${{ steps.apply-second-change.outputs.foreach }}" == "" ]]; then
+            echo "::error:: output foreach not set correctly"
+            exit 1
+          fi
+
+          if [[ "${{ steps.apply-second-change.outputs.count }}" != "${{ steps.apply-first-change.outputs.count }}" ]]; then
+            echo "::error:: Targeted change has affected untargeted resources"
+            exit 1
+          fi
+
+      - name: Auto Apply targeted change
+        uses: ./terraform-apply
+        id: apply-third-change
+        with:
+          path: tests/target
+          target: |
+            random_string.count[0]
+            random_string.foreach["hello"]
+          variables: |
+            length = 10
+          auto_approve: true
+
+      - name: Verify outputs
+        run: |
+          if [[ "${{ steps.apply-third-change.outputs.count }}" == "${{ steps.apply-second-change.outputs.count }}" ]]; then
+            echo "::error:: Targeted change has not affected targeted resources"
+            exit 1
+          fi
+
+          if [[ "${{ steps.apply-third-change.outputs.foreach }}" == "${{ steps.apply-second-change.outputs.foreach }}" ]]; then
+            echo "::error:: Targeted change has not affected targeted resources"
+            exit 1
+          fi
+
+      - name: Plan targeted replacement
+        uses: ./terraform-plan
+        id: plan-targeted-replacement
+        with:
+          path: tests/target
+          target: |
+            random_string.foreach["hello"]
+          replace: |
+            random_string.foreach["hello"]
+            random_string.count[0]
+          variables: |
+            length = 10
+
+      - name: Verify outputs
+        run: |
+          if [[ "${{ steps.plan-targeted-replacement.outputs.changes }}" != "true" ]]; then
+            echo "::error:: Targeted replacement should have changes"
+            exit 1
+          fi
+
+      - name: Apply targeted replacement
+        uses: ./terraform-apply
+        id: apply-targeted-replacement
+        with:
+          path: tests/target
+          target: |
+            random_string.foreach["hello"]
+          replace: |
+            random_string.foreach["hello"]
+            random_string.count[0]
+          variables: |
+            length = 10
+
+      - name: Verify outputs
+        run: |
+          if [[ "${{ steps.apply-targeted-replacement.outputs.count }}" != "${{ steps.apply-third-change.outputs.count }}" ]]; then
+            echo "::error:: Targeted replacement has affected non targeted resources"
+            exit 1
+          fi
+
+          if [[ "${{ steps.apply-targeted-replacement.outputs.foreach }}" == "${{ steps.apply-third-change.outputs.foreach }}" ]]; then
+            echo "::error:: Targeted replacement has not affected targeted resources"
+            exit 1
+          fi
+
+      - name: Plan replacement
+        uses: ./terraform-plan
+        id: plan-replacement
+        with:
+          path: tests/target
+          replace: |
+            random_string.foreach["hello"]
+            random_string.count[0]
+          variables: |
+            length = 10
+
+      - name: Verify outputs
+        run: |
+          if [[ "${{ steps.plan-replacement.outputs.changes }}" != "true" ]]; then
+            echo "::error:: Replacement should have changes"
+            exit 1
+          fi
+
+      - name: Apply replacement
+        uses: ./terraform-apply
+        id: apply-replacement
+        with:
+          path: tests/target
+          replace: |
+            random_string.foreach["hello"]
+            random_string.count[0]
+          variables: |
+            length = 10
+
+      - name: Verify outputs
+        run: |
+          if [[ "${{ steps.apply-replacement.outputs.count }}" == "${{ steps.apply-targeted-replacement.outputs.count }}" ]]; then
+            echo "::error:: Replacement has not affected targeted resources"
+            exit 1
+          fi
+
+          if [[ "${{ steps.apply-replacement.outputs.foreach }}" == "${{ steps.apply-targeted-replacement.outputs.foreach }}" ]]; then
+            echo "::error:: Replacement has not affected targeted resources"
+            exit 1
+          fi

--- a/image/actions.sh
+++ b/image/actions.sh
@@ -196,9 +196,10 @@ function select-workspace() {
 
 function set-common-plan-args() {
     PLAN_ARGS=""
+    PARALLEL_ARG=""
 
     if [[ "$INPUT_PARALLELISM" -ne 0 ]]; then
-        PLAN_ARGS="$PLAN_ARGS -parallelism=$INPUT_PARALLELISM"
+        PARALLEL_ARG="-parallelism=$INPUT_PARALLELISM"
     fi
 
     if [[ -v INPUT_TARGET ]]; then
@@ -306,11 +307,11 @@ function plan() {
         PLAN_OUT_ARG=""
     fi
 
-    debug_log terraform plan -input=false -no-color -detailed-exitcode -lock-timeout=300s $PLAN_OUT_ARG $PLAN_ARGS
+    debug_log terraform plan -input=false -no-color -detailed-exitcode -lock-timeout=300s $PARALLEL_ARG $PLAN_OUT_ARG $PLAN_ARGS
 
     set +e
     # shellcheck disable=SC2086
-    (cd "$INPUT_PATH" && terraform plan -input=false -no-color -detailed-exitcode -lock-timeout=300s $PLAN_OUT_ARG $PLAN_ARGS) \
+    (cd "$INPUT_PATH" && terraform plan -input=false -no-color -detailed-exitcode -lock-timeout=300s $PARALLEL_ARG $PLAN_OUT_ARG $PLAN_ARGS) \
         2>"$STEP_TMP_DIR/terraform_plan.stderr" \
         | $TFMASK \
         | tee /dev/fd/3 \

--- a/image/actions.sh
+++ b/image/actions.sh
@@ -211,14 +211,13 @@ function set-common-plan-args() {
     fi
 
     if [[ -v INPUT_REPLACE ]]; then
-      if [[ -n "$INPUT_REPLACE" ]]; then
-          for target in $(echo "$INPUT_REPLACE" | tr ',' '\n'); do
-              PLAN_ARGS="$PLAN_ARGS -replace $target"
-          done
-      fi
+        if [[ -n "$INPUT_REPLACE" ]]; then
+            for target in $(echo "$INPUT_REPLACE" | tr ',' '\n'); do
+                PLAN_ARGS="$PLAN_ARGS -replace $target"
+            done
+        fi
     fi
 }
-
 
 function set-plan-args() {
     set-common-plan-args
@@ -251,7 +250,7 @@ function set-remote-plan-args() {
     if [[ -n "$INPUT_VAR_FILE" ]]; then
         for file in $(echo "$INPUT_VAR_FILE" | tr ',' '\n'); do
             cp "$file" "$INPUT_PATH/zzzz-dflook-terraform-github-actions-$AUTO_TFVARS_COUNTER.auto.tfvars"
-            AUTO_TFVARS_COUNTER=$(( AUTO_TFVARS_COUNTER + 1 ))
+            AUTO_TFVARS_COUNTER=$((AUTO_TFVARS_COUNTER + 1))
         done
     fi
 
@@ -291,8 +290,8 @@ function write_credentials() {
 
     chmod 700 /.ssh
     if [[ -v TERRAFORM_SSH_KEY ]]; then
-      echo "$TERRAFORM_SSH_KEY" >>/.ssh/id_rsa
-      chmod 600 /.ssh/id_rsa
+        echo "$TERRAFORM_SSH_KEY" >>/.ssh/id_rsa
+        chmod 600 /.ssh/id_rsa
     fi
 
     debug_cmd git config --list
@@ -331,9 +330,9 @@ function destroy() {
     set +e
     # shellcheck disable=SC2086
     (cd "$INPUT_PATH" && terraform destroy -input=false -auto-approve -lock-timeout=300s $PARALLEL_ARG $PLAN_ARGS) \
-      2>"$STEP_TMP_DIR/terraform_destroy.stderr" \
-      | tee /dev/fd/3 \
-        >"$STEP_TMP_DIR/terraform_destroy.stdout"
+        2>"$STEP_TMP_DIR/terraform_destroy.stderr" \
+        | tee /dev/fd/3 \
+            >"$STEP_TMP_DIR/terraform_destroy.stdout"
 
     # shellcheck disable=SC2034
     DESTROY_EXIT=${PIPESTATUS[0]}

--- a/image/actions.sh
+++ b/image/actions.sh
@@ -322,6 +322,19 @@ function plan() {
     set -e
 }
 
+function destroy() {
+    debug_log terraform destroy -input=false -auto-approve -lock-timeout=300s $PARALLEL_ARG $PLAN_ARGS
+
+    set +e
+    (cd "$INPUT_PATH" && terraform destroy -input=false -auto-approve -lock-timeout=300s $PARALLEL_ARG $PLAN_ARGS) \
+      2>"$STEP_TMP_DIR/terraform_destroy.stderr" \
+      | tee /dev/fd/3 \
+        >"$STEP_TMP_DIR/terraform_destroy.stdout"
+
+    DESTROY_EXIT=${PIPESTATUS[0]}
+    set -e
+}
+
 # Every file written to disk should use one of these directories
 readonly STEP_TMP_DIR="/tmp"
 readonly JOB_TMP_DIR="$HOME/.dflook-terraform-github-actions"

--- a/image/actions.sh
+++ b/image/actions.sh
@@ -307,6 +307,7 @@ function plan() {
         PLAN_OUT_ARG=""
     fi
 
+    # shellcheck disable=SC2086
     debug_log terraform plan -input=false -no-color -detailed-exitcode -lock-timeout=300s $PARALLEL_ARG $PLAN_OUT_ARG $PLAN_ARGS
 
     set +e
@@ -318,27 +319,32 @@ function plan() {
         | compact_plan \
             >"$STEP_TMP_DIR/plan.txt"
 
+    # shellcheck disable=SC2034
     PLAN_EXIT=${PIPESTATUS[0]}
     set -e
 }
 
 function destroy() {
+    # shellcheck disable=SC2086
     debug_log terraform destroy -input=false -auto-approve -lock-timeout=300s $PARALLEL_ARG $PLAN_ARGS
 
     set +e
+    # shellcheck disable=SC2086
     (cd "$INPUT_PATH" && terraform destroy -input=false -auto-approve -lock-timeout=300s $PARALLEL_ARG $PLAN_ARGS) \
       2>"$STEP_TMP_DIR/terraform_destroy.stderr" \
       | tee /dev/fd/3 \
         >"$STEP_TMP_DIR/terraform_destroy.stdout"
 
+    # shellcheck disable=SC2034
     DESTROY_EXIT=${PIPESTATUS[0]}
     set -e
 }
 
 # Every file written to disk should use one of these directories
-readonly STEP_TMP_DIR="/tmp"
-readonly JOB_TMP_DIR="$HOME/.dflook-terraform-github-actions"
-readonly WORKSPACE_TMP_DIR=".dflook-terraform-github-actions/$(random_string)"
+STEP_TMP_DIR="/tmp"
+JOB_TMP_DIR="$HOME/.dflook-terraform-github-actions"
+WORKSPACE_TMP_DIR=".dflook-terraform-github-actions/$(random_string)"
+readonly STEP_TMP_DIR JOB_TMP_DIR WORKSPACE_TMP_DIR
 export STEP_TMP_DIR JOB_TMP_DIR WORKSPACE_TMP_DIR
 
 function fix_owners() {

--- a/image/entrypoints/apply.sh
+++ b/image/entrypoints/apply.sh
@@ -11,12 +11,6 @@ set-plan-args
 
 PLAN_OUT="$STEP_TMP_DIR/plan.out"
 
-if [[ "$INPUT_AUTO_APPROVE" == "true" && -n "$INPUT_TARGET" ]]; then
-    for target in $(echo "$INPUT_TARGET" | tr ',' '\n'); do
-        PLAN_ARGS="$PLAN_ARGS -target $target"
-    done
-fi
-
 if [[ -v GITHUB_TOKEN ]]; then
     update_status "Applying plan in $(job_markdown_ref)"
 fi
@@ -24,6 +18,8 @@ fi
 exec 3>&1
 
 function apply() {
+
+    debug_log terraform apply -input=false -no-color -auto-approve -lock-timeout=300s $PLAN_OUT
 
     set +e
     # shellcheck disable=SC2086

--- a/image/entrypoints/apply.sh
+++ b/image/entrypoints/apply.sh
@@ -22,6 +22,7 @@ function apply() {
 
     set +e
     if [[ -n "$PLAN_OUT" ]]; then
+        # shellcheck disable=SC2086
         debug_log terraform apply -input=false -no-color -auto-approve -lock-timeout=300s $PARALLEL_ARG $PLAN_OUT
         # shellcheck disable=SC2086
         (cd "$INPUT_PATH" && terraform apply -input=false -no-color -auto-approve -lock-timeout=300s $PARALLEL_ARG $PLAN_OUT) | $TFMASK
@@ -30,6 +31,7 @@ function apply() {
         # There is no plan file to apply, since the remote backend can't produce them.
         # Instead we need to do an auto approved apply using the arguments we would normally use for the plan
 
+        # shellcheck disable=SC2086
         debug_log terraform apply -input=false -no-color -auto-approve -lock-timeout=300s $PARALLEL_ARG $PLAN_ARGS
         # shellcheck disable=SC2086
         (cd "$INPUT_PATH" && terraform apply -input=false -no-color -auto-approve -lock-timeout=300s $PARALLEL_ARG $PLAN_ARGS) | $TFMASK

--- a/image/entrypoints/apply.sh
+++ b/image/entrypoints/apply.sh
@@ -65,7 +65,7 @@ if [[ $PLAN_EXIT -eq 1 ]]; then
 fi
 
 if [[ $PLAN_EXIT -eq 1 ]]; then
-    cat "$STEP_TMP_DIR/terraform_plan.stderr"
+    cat >&2 "$STEP_TMP_DIR/terraform_plan.stderr"
 
     update_status "Error applying plan in $(job_markdown_ref)"
     exit 1

--- a/image/entrypoints/check.sh
+++ b/image/entrypoints/check.sh
@@ -26,6 +26,7 @@ fi
 
 if [[ $PLAN_EXIT -eq 1 ]]; then
     echo "Error running terraform"
+    cat >&2 "$STEP_TMP_DIR/terraform_plan.stderr"
     exit 1
 
 elif [[ $PLAN_EXIT -eq 2 ]]; then

--- a/image/entrypoints/destroy-workspace.sh
+++ b/image/entrypoints/destroy-workspace.sh
@@ -9,8 +9,10 @@ init-backend
 select-workspace
 set-plan-args
 
+debug_log terraform destroy -input=false -auto-approve -lock-timeout=300s $PARALLEL_ARG $PLAN_ARGS
+
 # shellcheck disable=SC2086
-if ! (cd "$INPUT_PATH" && terraform destroy -input=false -auto-approve -lock-timeout=300s $PLAN_ARGS); then
+if ! (cd "$INPUT_PATH" && terraform destroy -input=false -auto-approve -lock-timeout=300s $PARALLEL_ARG $PLAN_ARGS); then
     set_output failure-reason destroy-failed
     exit 1
 fi

--- a/image/entrypoints/destroy-workspace.sh
+++ b/image/entrypoints/destroy-workspace.sh
@@ -21,6 +21,7 @@ if [[ $DESTROY_EXIT -eq 1 ]]; then
 fi
 
 if [[ $DESTROY_EXIT -eq 1 ]]; then
+    cat >&2 "$STEP_TMP_DIR/terraform_destroy.stderr"
     set_output failure-reason destroy-failed
     exit 1
 fi

--- a/image/entrypoints/destroy-workspace.sh
+++ b/image/entrypoints/destroy-workspace.sh
@@ -9,10 +9,18 @@ init-backend
 select-workspace
 set-plan-args
 
-debug_log terraform destroy -input=false -auto-approve -lock-timeout=300s $PARALLEL_ARG $PLAN_ARGS
+exec 3>&1
 
-# shellcheck disable=SC2086
-if ! (cd "$INPUT_PATH" && terraform destroy -input=false -auto-approve -lock-timeout=300s $PARALLEL_ARG $PLAN_ARGS); then
+destroy
+
+if [[ $DESTROY_EXIT -eq 1 ]]; then
+    if grep -q "Run variables are currently not supported" "$STEP_TMP_DIR/terraform_destroy.stderr"; then
+        set-remote-plan-args
+        destroy
+    fi
+fi
+
+if [[ $DESTROY_EXIT -eq 1 ]]; then
     set_output failure-reason destroy-failed
     exit 1
 fi

--- a/image/entrypoints/destroy.sh
+++ b/image/entrypoints/destroy.sh
@@ -9,8 +9,10 @@ init-backend
 select-workspace
 set-plan-args
 
+debug_log terraform destroy -input=false -auto-approve -lock-timeout=300s $PARALLEL_ARG $PLAN_ARGS
+
 # shellcheck disable=SC2086
-if ! (cd "$INPUT_PATH" && terraform destroy -input=false -auto-approve -lock-timeout=300s $PLAN_ARGS); then
+if ! (cd "$INPUT_PATH" && terraform destroy -input=false -auto-approve -lock-timeout=300s $PARALLEL_ARG $PLAN_ARGS); then
     set_output failure-reason destroy-failed
     exit 1
 fi

--- a/image/entrypoints/destroy.sh
+++ b/image/entrypoints/destroy.sh
@@ -21,6 +21,7 @@ if [[ $DESTROY_EXIT -eq 1 ]]; then
 fi
 
 if [[ $DESTROY_EXIT -eq 1 ]]; then
+    cat >&2 "$STEP_TMP_DIR/terraform_destroy.stderr"
     set_output failure-reason destroy-failed
     exit 1
 fi

--- a/image/entrypoints/destroy.sh
+++ b/image/entrypoints/destroy.sh
@@ -9,10 +9,18 @@ init-backend
 select-workspace
 set-plan-args
 
-debug_log terraform destroy -input=false -auto-approve -lock-timeout=300s $PARALLEL_ARG $PLAN_ARGS
+exec 3>&1
 
-# shellcheck disable=SC2086
-if ! (cd "$INPUT_PATH" && terraform destroy -input=false -auto-approve -lock-timeout=300s $PARALLEL_ARG $PLAN_ARGS); then
+destroy
+
+if [[ $DESTROY_EXIT -eq 1 ]]; then
+    if grep -q "Run variables are currently not supported" "$STEP_TMP_DIR/terraform_destroy.stderr"; then
+        set-remote-plan-args
+        destroy
+    fi
+fi
+
+if [[ $DESTROY_EXIT -eq 1 ]]; then
     set_output failure-reason destroy-failed
     exit 1
 fi

--- a/image/tools/github_pr_comment.py
+++ b/image/tools/github_pr_comment.py
@@ -63,6 +63,8 @@ class ActionInputs(TypedDict):
     INPUT_WORKSPACE: str
     INPUT_LABEL: str
     INPUT_ADD_GITHUB_COMMENT: str
+    INPUT_TARGET: str
+    INPUT_REPLACE: str
 
 
 def plan_identifier(action_inputs: ActionInputs) -> str:
@@ -110,6 +112,14 @@ def plan_identifier(action_inputs: ActionInputs) -> str:
 
     if action_inputs["INPUT_WORKSPACE"] != 'default':
         label += f' in the __{action_inputs["INPUT_WORKSPACE"]}__ workspace'
+
+    if action_inputs["INPUT_TARGET"]:
+        label += '\nTargeting resources: '
+        label += ', '.join(f'`{res.strip()}`' for res in action_inputs['INPUT_TARGET'].splitlines())
+
+    if action_inputs["INPUT_REPLACE"]:
+        label += '\nReplacing resources: '
+        label += ', '.join(f'`{res.strip()}`' for res in action_inputs['INPUT_REPLACE'].splitlines())
 
     backend_config = mask_backend_config()
     if backend_config:

--- a/terraform-apply/README.md
+++ b/terraform-apply/README.md
@@ -129,11 +129,26 @@ These input values must be the same as any `terraform-plan` for the same configu
   - Optional
   - Default: 10
 
+* `replace`
+
+  List of resources to replace if any update to them is required.
+
+  Only available with supported terraform versions (v0.15.2 onwards).
+
+  ```yaml
+  with:
+    replace: |
+      kubernetes_secret.tls_cert_public
+      kubernetes_secret.tls_cert_private
+  ```
+
+  - Type: string
+  - Optional
+
 * `target`
 
   List of resources to apply, one per line.
   The apply operation will be limited to these resources and their dependencies.
-  This only takes effect if auto_approve is also set to `true`.
 
   ```yaml
   with:

--- a/terraform-apply/action.yaml
+++ b/terraform-apply/action.yaml
@@ -43,7 +43,11 @@ inputs:
     description: Automatically approve and apply plan
     default: false
   target:
-    description: List of targets to apply against, one per line
+    description: List of resources to target for the apply, one per line
+    required: false
+    default: ""
+  replace:
+    description: List of resources to replace if an update is required, one per line
     required: false
     default: ""
 

--- a/terraform-plan/README.md
+++ b/terraform-plan/README.md
@@ -9,7 +9,7 @@ If the triggering event relates to a PR it will add a comment on the PR containi
     <img src="plan.png" width="600">
 </p>
 
-The `GITHUB_TOKEN` environment variable is must be set for the PR comment to be added.
+The `GITHUB_TOKEN` environment variable must be set for the PR comment to be added.
 The action can be run on other events, which prints the plan to the workflow log.
 
 The [dflook/terraform-apply](https://github.com/dflook/terraform-github-actions/tree/master/terraform-apply) action can be used to apply the generated plan.
@@ -113,6 +113,36 @@ The [dflook/terraform-apply](https://github.com/dflook/terraform-github-actions/
   - Type: number
   - Optional
   - Default: 10
+
+* `replace`
+
+  List of resources to replace if any update to them is required, one per line.
+
+  Only available with terraform versions that support replace (v0.15.2 onwards).
+
+  ```yaml
+  with:
+    replace: |
+      random_password.database
+  ```
+
+  - Type: string
+  - Optional
+
+* `target`
+
+  List of resources to apply, one per line.
+  The plan will be limited to these resources and their dependencies.
+
+  ```yaml
+  with:
+    target: |
+      kubernetes_secret.tls_cert_public
+      kubernetes_secret.tls_cert_private
+  ```
+
+  - Type: string
+  - Optional
 
 * `add_github_comment`
 

--- a/terraform-plan/action.yaml
+++ b/terraform-plan/action.yaml
@@ -31,6 +31,14 @@ inputs:
     description: Limit the number of concurrent operations
     required: false
     default: 0
+  target:
+    description: List of resources to target for the plan, one per line
+    required: false
+    default: ""
+  replace:
+    description: List of resources to replace if an update is required, one per line
+    required: false
+    default: ""
   label:
     description: A friendly name for this plan
     required: false

--- a/tests/target/main.tf
+++ b/tests/target/main.tf
@@ -1,0 +1,23 @@
+resource "random_string" "count" {
+  count = 1
+
+  length = var.length
+}
+
+resource "random_string" "foreach" {
+  for_each = toset(["hello"])
+
+  length = var.length
+}
+
+variable "length" {
+
+}
+
+output "count" {
+  value = random_string.count[0].result
+}
+
+output "foreach" {
+  value = random_string.foreach["hello"].result
+}


### PR DESCRIPTION
TODO: plan-args need to be used for remote applies, where the plan is generated on the fly. This didn't matter before, but it will for replace/target.