### PR TITLE
Update Terraform "workspace does not exist" regex

### DIFF
--- a/image/actions.sh
+++ b/image/actions.sh
@@ -164,7 +164,7 @@ function init-backend() {
     if [[ $INIT_EXIT -eq 0 ]]; then
         cat "$STEP_TMP_DIR/terraform_init.stderr" >&2
     else
-        if grep -q "No existing workspaces." "$STEP_TMP_DIR/terraform_init.stderr" || grep -q "Failed to select workspace" "$STEP_TMP_DIR/terraform_init.stderr"; then
+        if grep -q "No existing workspaces." "$STEP_TMP_DIR/terraform_init.stderr" || grep -q "Failed to select workspace" "$STEP_TMP_DIR/terraform_init.stderr" || grep -q "Currently selected workspace.*does not exist" "$STEP_TMP_DIR/terraform_init.stderr"; then
             # Couldn't select workspace, but we don't really care.
             # select-workspace will give a better error if the workspace is required to exist
             :


### PR DESCRIPTION
In Terraform 1.0.10 (hashicorp/terraform#29805), the error message was changed when `terraform init` is called with a non-existent workspace when the `-input=false` flag is passed. The error message now looks like this:

```
Error: Currently selected workspace "foo" does not exist
```

This appears to cause failures now when using the `dflook/terraform-new-workspace` action. This PR fixes it by adding a new regex in the `init-backend` function when determining why `terraform init` failed (whether it was an expected error due to the workspace not existing or an unexpected error).

*Heads-up: I haven't actually tested this change in a workflow myself (but I did at least test the new regex against the actual output from Terraform).*