### PR TITLE
Remove circular deprecation warning

### DIFF
--- a/terraform-destroy/action.yaml
+++ b/terraform-destroy/action.yaml
@@ -22,7 +22,6 @@ inputs:
   variables:
     description: Variable definitions
     required: false
-    deprecationMessage: Use the variables input instead.
   var:
     description: Comma separated list of vars to set, e.g. 'foo=bar'
     required: false


### PR DESCRIPTION
The other actions don't have this, so seems to be copied from the var deprecationMessage.