### PR TITLE
Use correct value for terraform.workspace when validating with remote backend

### DIFF
--- a/.github/workflows/test-http.yaml
+++ b/.github/workflows/test-http.yaml
@@ -87,7 +87,7 @@ jobs:
 
   git_no_credentials:
     runs-on: ubuntu-latest
-    name: git_http no creds
+    name: git+http no creds
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/test-validate.yaml
+++ b/.github/workflows/test-validate.yaml
@@ -52,7 +52,7 @@ jobs:
 
   validate_workspace:
     runs-on: ubuntu-latest
-    name: Use workspace name during validationg
+    name: Use workspace name during validation
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -87,3 +87,16 @@ jobs:
             echo "::error:: failure-reason not set correctly"
             exit 1
           fi
+
+  validate_remote_workspace:
+    runs-on: ubuntu-latest
+    name: Use workspace name during validation
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: validate prod
+        uses: ./terraform-validate
+        with:
+          path: tests/workflows/test-validate/workspace_eval_remote
+          workspace: prod

--- a/image/entrypoints/validate.sh
+++ b/image/entrypoints/validate.sh
@@ -11,12 +11,18 @@ setup
 # How do you get a full validation report? You can't.
 
 # terraform.workspace will be evaluated during a validate, but it is not initialized properly.
-# Pass through the workspace input, even if it doesn't make sense for some backends.
+# Pass through the workspace input, except for remote backend where it should be 'default'
+
+if [[ "$TERRAFORM_BACKEND_TYPE" == "remote" ]]; then
+  TF_WORKSPACE="default"
+else
+  TF_WORKSPACE="$INPUT_WORKSPACE"
+fi
 
 init || true
 
-if ! (cd "$INPUT_PATH" && TF_WORKSPACE="$INPUT_WORKSPACE" terraform validate -json | convert_validate_report "$INPUT_PATH"); then
-    (cd "$INPUT_PATH" && TF_WORKSPACE="$INPUT_WORKSPACE" terraform validate)
+if ! (cd "$INPUT_PATH" && TF_WORKSPACE="$TF_WORKSPACE" terraform validate -json | convert_validate_report "$INPUT_PATH"); then
+    (cd "$INPUT_PATH" && TF_WORKSPACE="$TF_WORKSPACE" terraform validate)
 else
     echo -e "\033[1;32mSuccess!\033[0m The configuration is valid"
 fi

--- a/tests/workflows/test-http/main.tf
+++ b/tests/workflows/test-http/main.tf
@@ -1,5 +1,5 @@
 module "git_https_source" {
-  source = "git::https://github.com/dflook/terraform-github-actions.git//tests/workflows/test-http/test-module"
+  source = "git::https://github.com/dflook/terraform-github-actions-dev.git//tests/workflows/test-http/test-module"
 }
 
 output "git_https" {

--- a/tests/workflows/test-http/main.tf
+++ b/tests/workflows/test-http/main.tf
@@ -1,5 +1,5 @@
 module "git_https_source" {
-  source = "git::https://github.com/dflook/terraform-github-actions-dev.git//tests/workflows/test-http/test-module"
+  source = "git::https://github.com/dflook/terraform-github-actions.git//tests/workflows/test-http/test-module"
 }
 
 output "git_https" {

--- a/tests/workflows/test-validate/workspace_eval_remote/main.tf
+++ b/tests/workflows/test-validate/workspace_eval_remote/main.tf
@@ -1,11 +1,6 @@
 locals {
   aws_provider_config = {
-    prod = {
-      region     = "..."
-      account_id = "..."
-      profile    = "..."
-    }
-    dev = {
+    default = {
       region     = "..."
       account_id = "..."
       profile    = "..."
@@ -22,3 +17,15 @@ provider "aws" {
 resource "aws_s3_bucket" "bucket" {
   bucket = "hello"
 }
+
+terraform {
+  backend "remote" {
+    hostname = "app.terraform.io"
+    organization = "flooktech"
+
+    workspaces {
+        name = "banana"
+    }
+  }
+}
+


### PR DESCRIPTION
Now we know the backend type, we can use the correct value for validation with
remote backends