### PR TITLE
Fix version regex not matching version links

### DIFF
--- a/image/src/terraform/versions.py
+++ b/image/src/terraform/versions.py
@@ -214,7 +214,7 @@ def get_terraform_versions() -> Iterable[Version]:
     response = session.get('https://releases.hashicorp.com/terraform/')
     response.raise_for_status()
 
-    version_regex = re.compile(br'/(\d+\.\d+\.\d+(-[\d\w]+)?)/')
+    version_regex = re.compile(br'/(\d+\.\d+\.\d+(-[\d\w]+)?)')
 
     for version in version_regex.finditer(response.content):
         yield Version(version.group(1).decode())


### PR DESCRIPTION
This morning, we started seeing failures across the `dflook/terraform-github-actions` actions that we use. After some digging, I found that the regex that this PR updates is no longer matching the current HTML from https://releases.hashicorp.com/terraform/.

Earlier, when I fetched that URL, I got links like this (which matches up with what the regex expects):

```html
<!-- ... --->
<li>
<a href="/terraform/1.1.9/">terraform_1.1.9</a>

</li>
<li>
<a href="/terraform/1.1.8/">terraform_1.1.8</a>

</li>
<!-- ... --->
```

Now, I see HTML that looks like this:

```html
<!-- ... --->
<li>
<a href="/terraform/1.1.9">terraform_1.1.9</a>

</li>
<li>
<a href="/terraform/1.1.8">terraform_1.1.8</a>

</li>
<!-- ... --->
```

Notice that the trailing `/` is now missing from the links!


The fix, then, should be pretty simple. I just updated the Regex to not match on the trailing `/`, which should work whether or not the link has a trailing `/`.