### PR TITLE
Fix compacting plans with only moved resources

### DIFF
--- a/image/tools/compact_plan.py
+++ b/image/tools/compact_plan.py
@@ -14,7 +14,8 @@ def compact_plan(input):
             line.startswith('An execution plan has been generated and is shown below') or
             line.startswith('No changes') or
             line.startswith('Error') or
-            line.startswith('Changes to Outputs:')
+            line.startswith('Changes to Outputs:') or
+            line.startswith('Terraform will perform the following actions:')
         ):
             plan = True
 

--- a/tests/test_compact_plan.py
+++ b/tests/test_compact_plan.py
@@ -510,6 +510,37 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     output = '\n'.join(compact_plan(input.splitlines()))
     assert output == expected_output
 
+def test_plan_refresh_changes_16():
+    input = """
+random_string.my_string: Refreshing state... [id=Iyh3jLKc]
+
+Terraform will perform the following actions:
+
+  # random_string.your_string has moved to random_string.my_string
+    resource "random_string" "my_string" {
+        id          = "Iyh3jLKc"
+        length      = 8
+        # (8 unchanged attributes hidden)
+    }
+
+Plan: 0 to add, 0 to change, 0 to destroy.
+        """
+
+    expected_output = """Terraform will perform the following actions:
+
+  # random_string.your_string has moved to random_string.my_string
+    resource "random_string" "my_string" {
+        id          = "Iyh3jLKc"
+        length      = 8
+        # (8 unchanged attributes hidden)
+    }
+
+Plan: 0 to add, 0 to change, 0 to destroy.
+        """
+
+    output = '\n'.join(compact_plan(input.splitlines()))
+    assert output == expected_output
+
 def test_error_11():
     input = """
 Error: random_string.my_string: length: cannot parse '' as int: strconv.ParseInt: parsing "ten": invalid syntax


### PR DESCRIPTION
I've encountered an issue similar to #54 when refactoring some Terraform config using [`moved` blocks](https://www.terraform.io/language/modules/develop/refactoring).

The plan generated when there are no other changes than moving resources doesn't contain any other magical keywords listed in `compact_plan` (see the example plan in the test) 😞 