### PR TITLE
fix: check if plan too long for pr comment

### DIFF
--- a/.github/workflows/test-plan.yaml
+++ b/.github/workflows/test-plan.yaml
@@ -50,6 +50,68 @@ jobs:
           echo "if expression should not have evaluated true"
           exit 1
 
+  too_long:
+    runs-on: ubuntu-latest
+    name: Plan too long
+    env:
+      TF_PLAN_COMMENT_LENGTH: 1
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Plan
+        uses: ./terraform-plan
+        id: plan
+        with:
+          path: tests/workflows/test-plan/plan
+
+      - name: Verify outputs
+        run: |
+          echo "changes=${{ steps.plan.outputs.changes }}"
+
+          if [[ "${{ steps.plan.outputs.changes }}" != "true" ]]; then
+            echo "::error:: output changes not set correctly"
+            exit 1
+          fi
+
+          cat '${{ steps.plan.outputs.json_plan_path }}'
+          if [[ $(jq -r .output_changes.s.actions[0] "${{ steps.plan.outputs.json_plan_path }}") != "create" ]]; then
+            echo "::error:: json_plan_path not set correctly"
+            exit 1
+          fi
+
+          if ! grep -q "Terraform will perform the following actions" '${{ steps.plan.outputs.text_plan_path }}'; then
+            echo "::error:: text_plan_path not set correctly"
+            exit 1
+          fi
+
+          if [[ ${{ steps.plan.outputs.to_add }} -ne 1 ]]; then
+            echo "::error:: to_add not set correctly"
+            exit 1
+          fi
+
+          if [[ ${{ steps.plan.outputs.to_change }} -ne 0 ]]; then
+            echo "::error:: to_change not set correctly"
+            exit 1
+          fi
+
+          if [[ ${{ steps.plan.outputs.to_destroy }} -ne 0 ]]; then
+            echo "::error:: to_destroy not set correctly"
+            exit 1
+          fi
+
+          if [[ -n "${{ steps.apply.outputs.run_id }}" ]]; then
+            echo "::error:: run_id should not be set"
+            exit 1
+          fi
+
+      - name: Test output expressions
+        if: steps.plan.outputs.to_add != 1 || steps.plan.outputs.to_change != 0 || steps.plan.outputs.to_destroy != 0
+        run: |
+          echo "if expression should not have evaluated true"
+          exit 1
+
   no_changes_no_comment:
     runs-on: ubuntu-latest
     name: No changes without comment

--- a/terraform-plan/README.md
+++ b/terraform-plan/README.md
@@ -285,6 +285,20 @@ The [dflook/terraform-apply](https://github.com/dflook/terraform-github-actions/
   - Optional
   - Default: 10
 
+* `TF_PLAN_COMMENT_LENGTH`
+
+  If a terraform plan has more lines than this value, only a summary is included in the
+  PR comment with a message directing users to the workflow link for full details.
+
+  ```yaml
+  env:
+    TF_PLAN_COMMENT_LENGTH: 10000
+  ```
+
+  - Type: integer
+  - Optional
+  - Default: 65000
+
 * `TERRAFORM_PRE_RUN`
 
   A set of commands that will be ran prior to `terraform init`. This can be used to customise the environment before running terraform. 


### PR DESCRIPTION
This change adds a check for plans that have summaries longer than the allowed length of a GitHub PR comment (approx. 65,000 characters). If a plan exceeds this length (or a different value configured by env variable `TF_PLAN_COMMENT_LENGTH`) the summary is replaced by this message:

```
Plan exceeds comment maximum comment length, please see the link below for the full details.
```

Closes #197 
Closes #133 