### PR TITLE
Terraform plan with -refresh argument

### DIFF
--- a/image/actions.sh
+++ b/image/actions.sh
@@ -252,9 +252,14 @@ function select-workspace() {
 function set-common-plan-args() {
     PLAN_ARGS=""
     PARALLEL_ARG=""
+    REFRESH_ARG=""
 
     if [[ "$INPUT_PARALLELISM" -ne 0 ]]; then
         PARALLEL_ARG="-parallelism=$INPUT_PARALLELISM"
+    fi
+    
+    if [[ -v INPUT_REFRESH ]]; then
+        REFRESH_ARG="-refresh=$INPUT_REFRESH"
     fi
 
     if [[ -v INPUT_TARGET ]]; then
@@ -363,11 +368,11 @@ function plan() {
     fi
 
     # shellcheck disable=SC2086
-    debug_log terraform plan -input=false -no-color -detailed-exitcode -lock-timeout=300s $PARALLEL_ARG $PLAN_OUT_ARG '$PLAN_ARGS'  # don't expand PLAN_ARGS
+    debug_log terraform plan -input=false -no-color -detailed-exitcode -lock-timeout=300s $PARALLEL_ARG $REFRESH_ARG $PLAN_OUT_ARG '$PLAN_ARGS'  # don't expand PLAN_ARGS
 
     set +e
     # shellcheck disable=SC2086
-    (cd "$INPUT_PATH" && terraform plan -input=false -no-color -detailed-exitcode -lock-timeout=300s $PARALLEL_ARG $PLAN_OUT_ARG $PLAN_ARGS) \
+    (cd "$INPUT_PATH" && terraform plan -input=false -no-color -detailed-exitcode -lock-timeout=300s $PARALLEL_ARG $REFRESH_ARG $PLAN_OUT_ARG $PLAN_ARGS) \
         2>"$STEP_TMP_DIR/terraform_plan.stderr" \
         | $TFMASK \
         | tee /dev/fd/3 "$STEP_TMP_DIR/terraform_plan.stdout" \

--- a/image/src/github_actions/inputs.py
+++ b/image/src/github_actions/inputs.py
@@ -21,6 +21,7 @@ class PlanInputs(InitInputs):
     INPUT_VAR: str
     INPUT_VAR_FILE: str
     INPUT_PARALLELISM: str
+    INPUT_REFRESH: str
 
 
 class PlanPrInputs(PlanInputs):

--- a/terraform-plan/README.md
+++ b/terraform-plan/README.md
@@ -154,6 +154,14 @@ The [dflook/terraform-apply](https://github.com/dflook/terraform-github-actions/
   - Optional
   - Default: The terraform default (10)
 
+* `refresh`
+
+  Synchronize the Terraform state with remote objects before checking for configuration changes, if `false` external changes will be ignored
+
+  - Type: boolean
+  - Optional
+  - Default: `true`
+
 * ~~`var`~~
 
   > :warning: **Deprecated**: Use the `variables` input instead.

--- a/terraform-plan/action.yaml
+++ b/terraform-plan/action.yaml
@@ -41,6 +41,10 @@ inputs:
     description: List of resources to replace if an update is required, one per line
     required: false
     default: ""
+  refresh:
+    description: Synchronize the Terraform state with remote objects before checking for configuration changes, if false external changes will be ignored.
+    required: false
+    default: "true"
   label:
     description: A friendly name for this plan
     required: false


### PR DESCRIPTION
Sometimes we need to run `terraform-plan` with option `-refresh=false` to ignore external changes.
[Planning Options](https://www.terraform.io/cli/commands/plan#planning-options)