### PR TITLE
Update actions/checkout to v3

### DIFF
--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -19,7 +19,7 @@ jobs:
       DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Registry login
         run: |

--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run Labeler
         uses: crazy-max/ghaction-github-labeler@52525cb66833763f651fc34e244e4f73b6e07ff5

--- a/.github/workflows/pull_request_review.yaml
+++ b/.github/workflows/pull_request_review.yaml
@@ -11,7 +11,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: ./terraform-plan

--- a/.github/workflows/pull_request_target.yaml
+++ b/.github/workflows/pull_request_target.yaml
@@ -11,7 +11,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: ./terraform-plan

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Registry login
         env:
@@ -49,9 +49,9 @@ jobs:
 
       - name: Release actions
         run: |
-          export RELEASE_TAG="${{ github.event.release.tag_name }}"
-          export major=`echo $RELEASE_TAG | cut -d. -f1`
-          export minor=`echo $RELEASE_TAG | cut -d. -f2`
+          RELEASE_TAG="${{ github.event.release.tag_name }}"
+          major=$(echo $RELEASE_TAG | cut -d. -f1)
+          minor=$(echo $RELEASE_TAG | cut -d. -f2)
 
           git config --global user.name "Daniel Flook"
           git config --global user.email "daniel@flook.org"
@@ -62,6 +62,7 @@ jobs:
               echo "Releasing dflook/$action@$RELEASE_TAG"
 
               rsync -r $GITHUB_WORKSPACE/$action/ $HOME/$action
+              cp $GITHUB_WORKSPACE/.github/FUNDING.yaml $HOME/$action/.github
 
               sed -i "s|../image/Dockerfile|docker://${{ steps.image_build.outputs.digest }}|" $HOME/$action/action.yaml
 

--- a/.github/workflows/retain-images.yaml
+++ b/.github/workflows/retain-images.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Pull images
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test-apply.yaml
+++ b/.github/workflows/test-apply.yaml
@@ -12,7 +12,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Apply
         uses: ./terraform-apply
@@ -48,7 +48,7 @@ jobs:
     name: Auto Approve plan error
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Apply
         uses: ./terraform-apply
@@ -94,7 +94,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: ./terraform-plan
@@ -143,7 +143,7 @@ jobs:
     name: Apply without token
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Apply
         uses: ./terraform-apply
@@ -176,7 +176,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: ./terraform-plan
@@ -249,7 +249,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: ./terraform-plan
@@ -340,7 +340,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: ./terraform-plan
@@ -431,7 +431,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: ./terraform-plan
@@ -520,7 +520,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: ./terraform-plan
@@ -570,7 +570,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Apply
         uses: ./terraform-apply
@@ -608,7 +608,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Apply
         uses: ./terraform-apply
@@ -647,7 +647,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.USER_GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: ./terraform-plan
@@ -691,7 +691,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: ./terraform-plan
@@ -735,7 +735,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan 1
         uses: ./terraform-plan
@@ -807,7 +807,7 @@ jobs:
         echo "testing command 2"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: ./terraform-plan
@@ -836,7 +836,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: ./terraform-plan
@@ -861,7 +861,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: dflook/terraform-plan@v1.22.2
@@ -886,7 +886,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: ./terraform-plan
@@ -907,7 +907,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: ./terraform-plan

--- a/.github/workflows/test-changes-only.yaml
+++ b/.github/workflows/test-changes-only.yaml
@@ -11,7 +11,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan without changes
         uses: ./terraform-plan
@@ -51,7 +51,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan changes
         uses: ./terraform-plan
@@ -114,7 +114,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan no changes
         uses: ./terraform-plan
@@ -164,7 +164,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan Changes
         uses: ./terraform-plan

--- a/.github/workflows/test-check.yaml
+++ b/.github/workflows/test-check.yaml
@@ -9,7 +9,7 @@ jobs:
     name: No changes
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Check
         uses: ./terraform-check
@@ -29,7 +29,7 @@ jobs:
     name: Changes
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Check
         uses: ./terraform-check

--- a/.github/workflows/test-cloud.yaml
+++ b/.github/workflows/test-cloud.yaml
@@ -13,7 +13,7 @@ jobs:
         tf_version: ['0.13', '1.0']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Create a new workspace with no existing workspaces
         uses: ./terraform-new-workspace

--- a/.github/workflows/test-fmt-check.yaml
+++ b/.github/workflows/test-fmt-check.yaml
@@ -9,7 +9,7 @@ jobs:
     name: Canonical fmt
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: fmt-check
         uses: ./terraform-fmt-check
@@ -30,7 +30,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: fmt-check
         uses: ./terraform-fmt-check

--- a/.github/workflows/test-fmt.yaml
+++ b/.github/workflows/test-fmt.yaml
@@ -9,7 +9,7 @@ jobs:
     name: Canonical fmt
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: terraform fmt
         uses: ./terraform-fmt

--- a/.github/workflows/test-http.yaml
+++ b/.github/workflows/test-http.yaml
@@ -17,7 +17,7 @@ jobs:
         github.com/dflook/terraform-github-actions-dev.git=dflook:${{ secrets.USER_GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Apply
         uses: ./terraform-apply
@@ -43,7 +43,7 @@ jobs:
         github.com/dflook=dflook:${{ secrets.USER_GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Apply
         uses: ./terraform-apply
@@ -69,7 +69,7 @@ jobs:
         github.com=dflook:${{ secrets.USER_GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Apply
         uses: ./terraform-apply
@@ -90,7 +90,7 @@ jobs:
     name: git+http no creds
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Apply
         uses: ./terraform-apply
@@ -115,7 +115,7 @@ jobs:
         5qcb7mjppk.execute-api.eu-west-2.amazonaws.com=dflook:hello
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Apply
         uses: ./terraform-apply
@@ -136,7 +136,7 @@ jobs:
     name: http module source with no credentials
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Apply
         uses: ./terraform-apply

--- a/.github/workflows/test-new-workspace.yaml
+++ b/.github/workflows/test-new-workspace.yaml
@@ -16,7 +16,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup remote backend
         run: |

--- a/.github/workflows/test-output.yaml
+++ b/.github/workflows/test-output.yaml
@@ -13,7 +13,7 @@ jobs:
     name: verify outputs
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get outputs
         uses: ./terraform-output

--- a/.github/workflows/test-plan.yaml
+++ b/.github/workflows/test-plan.yaml
@@ -11,7 +11,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: ./terraform-plan
@@ -57,7 +57,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: ./terraform-plan
@@ -91,7 +91,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: ./terraform-plan
@@ -151,7 +151,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: ./terraform-plan
@@ -212,7 +212,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: ./terraform-plan
@@ -274,7 +274,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: ./terraform-plan
@@ -336,7 +336,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: ./terraform-plan
@@ -397,7 +397,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: ./terraform-plan
@@ -458,7 +458,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: ./terraform-plan
@@ -519,7 +519,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: ./terraform-plan
@@ -553,7 +553,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: ./terraform-plan
@@ -597,7 +597,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: ./terraform-plan
@@ -634,7 +634,7 @@ jobs:
     name: Add comment without token
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: ./terraform-plan
@@ -672,7 +672,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: ./terraform-plan
@@ -689,7 +689,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: ./terraform-plan
@@ -708,7 +708,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Copy
         run: cp tests/workflows/test-plan/plan/main.tf ./main.tf

--- a/.github/workflows/test-registry.yaml
+++ b/.github/workflows/test-registry.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Use registry module
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: ./terraform-plan
@@ -49,7 +49,7 @@ jobs:
         app.terraform.io   =   ${{ secrets.TF_API_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: ./terraform-plan
@@ -76,7 +76,7 @@ jobs:
     name: Nonsense cloud credentials
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: ./terraform-plan

--- a/.github/workflows/test-remote-state.yaml
+++ b/.github/workflows/test-remote-state.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get remote state
         uses: ./terraform-remote-state

--- a/.github/workflows/test-ssh.yaml
+++ b/.github/workflows/test-ssh.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Git module source
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: ./terraform-plan
@@ -43,7 +43,7 @@ jobs:
     name: Git module source with no key
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan
         uses: ./terraform-plan

--- a/.github/workflows/test-target-replace.yaml
+++ b/.github/workflows/test-target-replace.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Plan targeting
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Plan with no changes in targets
         uses: ./terraform-plan
@@ -220,7 +220,7 @@ jobs:
     name: Remote Plan targeting
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup remote backend
         run: |

--- a/.github/workflows/test-validate.yaml
+++ b/.github/workflows/test-validate.yaml
@@ -9,7 +9,7 @@ jobs:
     name: valid
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: validate
         uses: ./terraform-validate
@@ -29,7 +29,7 @@ jobs:
     name: Invalid terraform configuration
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: validate
         uses: ./terraform-validate
@@ -55,7 +55,7 @@ jobs:
     name: Use workspace name during validation
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: validate prod
         uses: ./terraform-validate
@@ -93,7 +93,7 @@ jobs:
     name: Use workspace name during validation
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: validate prod
         uses: ./terraform-validate
@@ -106,7 +106,7 @@ jobs:
     name: Validate with unterminated string
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: validate
         uses: ./terraform-validate

--- a/.github/workflows/test-version.yaml
+++ b/.github/workflows/test-version.yaml
@@ -9,7 +9,7 @@ jobs:
     name: specific required_version
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Test terraform-version
         uses: ./terraform-version
@@ -32,7 +32,7 @@ jobs:
     name: required_version range
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Test terraform-version
         uses: ./terraform-version
@@ -55,7 +55,7 @@ jobs:
     name: tfswitch
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Test terraform-version
         uses: ./terraform-version
@@ -78,7 +78,7 @@ jobs:
     name: tfenv
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Test terraform-version
         uses: ./terraform-version
@@ -101,7 +101,7 @@ jobs:
     name: asdf
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Test terraform-version
         uses: ./terraform-version
@@ -124,7 +124,7 @@ jobs:
     name: TERRAFORM_VERSION range
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Test terraform-version
         uses: ./terraform-version
@@ -149,7 +149,7 @@ jobs:
     name: TFC Workspace
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Create workspace
         uses: ./terraform-new-workspace
@@ -189,7 +189,7 @@ jobs:
     name: TFC Cloud Configuration
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Create workspace
         uses: ./terraform-new-workspace
@@ -231,7 +231,7 @@ jobs:
     name: Local State file
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Test terraform-version
         uses: ./terraform-version
@@ -254,7 +254,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Apply default workspace
         uses: ./terraform-apply
@@ -385,7 +385,7 @@ jobs:
     name: latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Test terraform-version
         uses: ./terraform-version
@@ -408,7 +408,7 @@ jobs:
     name: provider versions
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Test terraform-version with 0.12
         uses: ./terraform-version

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
     name: pytest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: terraform plan
         uses: dflook/terraform-plan@v1
@@ -84,7 +84,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: terraform apply
         uses: dflook/terraform-apply@v1
@@ -117,7 +117,7 @@ jobs:
     name: Validate terraform configuration
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: terraform validate
         uses: dflook/terraform-validate@v1
@@ -129,7 +129,7 @@ jobs:
     name: Check formatting of terraform files
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: terraform fmt
         uses: dflook/terraform-fmt-check@v1
@@ -158,7 +158,7 @@ jobs:
     name: Check for drift of example terraform configuration
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Check for drift
         uses: dflook/terraform-check@v1
@@ -186,7 +186,7 @@ jobs:
     name: Rotate TLS certificates in example terraform configuration
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Rotate certs
         uses: dflook/terraform-apply@v1
@@ -216,7 +216,7 @@ jobs:
     name: Check terraform file are formatted correctly
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: terraform fmt
         uses: dflook/terraform-fmt@v1
@@ -254,7 +254,7 @@ jobs:
     name: Run integration tests
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use branch workspace
         uses: dflook/terraform-new-workspace@v1
@@ -290,7 +290,7 @@ jobs:
     name: Cleanup after integration tests
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: terraform destroy
         uses: dflook/terraform-destroy-workspace@v1

--- a/example_workflows/apply_plan.yaml
+++ b/example_workflows/apply_plan.yaml
@@ -13,7 +13,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: terraform apply
         uses: dflook/terraform-apply@v1

--- a/example_workflows/check_for_drift.yaml
+++ b/example_workflows/check_for_drift.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Check for drift of example terraform configuration
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Check
         uses: dflook/terraform-check@v1

--- a/example_workflows/create_plan.yaml
+++ b/example_workflows/create_plan.yaml
@@ -11,7 +11,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: terraform plan
         uses: dflook/terraform-plan@v1

--- a/example_workflows/fix_formatting.yaml
+++ b/example_workflows/fix_formatting.yaml
@@ -13,7 +13,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: terraform fmt
         uses: dflook/terraform-fmt@v1

--- a/example_workflows/validate.yaml
+++ b/example_workflows/validate.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Check formatting of terraform files
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: terraform fmt
         uses: dflook/terraform-fmt-check@v1
@@ -23,7 +23,7 @@ jobs:
     name: Validate terraform configuration
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: terraform validate
         uses: dflook/terraform-validate@v1

--- a/terraform-apply/README.md
+++ b/terraform-apply/README.md
@@ -376,7 +376,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: terraform apply
         uses: dflook/terraform-apply@v1
@@ -403,7 +403,7 @@ jobs:
     name: Apply terraform
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: terraform apply
         uses: dflook/terraform-apply@v1
@@ -430,7 +430,7 @@ jobs:
     name: Rotate certs
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: terraform apply
         uses: dflook/terraform-apply@v1
@@ -463,7 +463,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: refs/pull/${{ github.event.issue.number }}/merge
 
@@ -491,7 +491,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: terraform apply
         uses: dflook/terraform-apply@v1

--- a/terraform-check/README.md
+++ b/terraform-check/README.md
@@ -215,7 +215,7 @@ jobs:
     name: Check for drift of terraform configuration
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Check
         uses: dflook/terraform-check@v1
@@ -238,7 +238,7 @@ jobs:
     name: Check for drift of terraform configuration
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Check
         uses: dflook/terraform-check@v1

--- a/terraform-destroy-workspace/README.md
+++ b/terraform-destroy-workspace/README.md
@@ -208,7 +208,7 @@ jobs:
     name: Cleanup after integration tests
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: terraform destroy
         uses: dflook/terraform-destroy-workspace@v1
@@ -232,7 +232,7 @@ jobs:
     name: Destroy terraform workspace
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: terraform destroy
         uses: dflook/terraform-destroy-workspace@v1

--- a/terraform-destroy/README.md
+++ b/terraform-destroy/README.md
@@ -215,7 +215,7 @@ jobs:
     name: Destroy terraform workspace
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: terraform destroy
         uses: dflook/terraform-destroy@v1
@@ -239,7 +239,7 @@ jobs:
     name: Destroy terraform workspace
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: terraform destroy
         uses: dflook/terraform-destroy@v1

--- a/terraform-fmt-check/README.md
+++ b/terraform-fmt-check/README.md
@@ -101,7 +101,7 @@ jobs:
     name: Check terraform file are formatted correctly
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: terraform fmt
         uses: dflook/terraform-fmt-check@v1
@@ -122,7 +122,7 @@ jobs:
     name: Check terraform file are formatted correctly
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: terraform fmt
         uses: dflook/terraform-fmt-check@v1

--- a/terraform-fmt/README.md
+++ b/terraform-fmt/README.md
@@ -93,7 +93,7 @@ jobs:
     name: Check terraform file are formatted correctly
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: terraform fmt
         uses: dflook/terraform-fmt@v1

--- a/terraform-new-workspace/README.md
+++ b/terraform-new-workspace/README.md
@@ -148,7 +148,7 @@ jobs:
     name: Run integration tests
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use branch workspace
         uses: dflook/terraform-new-workspace@v1

--- a/terraform-output/README.md
+++ b/terraform-output/README.md
@@ -177,7 +177,7 @@ jobs:
     name: Show the terraformed hostname
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get outputs
         uses: dflook/terraform-output@v1
@@ -211,7 +211,7 @@ jobs:
     name: An example of workflow expressions with terraform output
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get outputs
         uses: dflook/terraform-output@v1

--- a/terraform-plan/README.md
+++ b/terraform-plan/README.md
@@ -379,7 +379,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}            
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: terraform plan
         uses: dflook/terraform-plan@v1
@@ -411,7 +411,7 @@ jobs:
     name: Create terraform plan
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: terraform plan
         uses: dflook/terraform-plan@v1
@@ -446,7 +446,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: refs/pull/${{ github.event.issue.number }}/merge
 

--- a/terraform-validate/README.md
+++ b/terraform-validate/README.md
@@ -169,7 +169,7 @@ jobs:
     name: Validate terraform
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: terraform validate
         uses: dflook/terraform-validate@v1
@@ -188,7 +188,7 @@ jobs:
     name: Validate terraform
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: terraform validate
         uses: dflook/terraform-validate@v1

--- a/terraform-version/README.md
+++ b/terraform-version/README.md
@@ -189,7 +189,7 @@ jobs:
     name: Print the required terraform  and provider versions
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Test terraform-version
         uses: dflook/terraform-version@v1


### PR DESCRIPTION
Updates actions/checkout to v3 in workflows, documentation and examples.
This resolves deprecation warnings about node 12 and the set-output workflow command.