### PR TITLE
Verify terraform archives

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,7 @@ jobs:
           BASE_DIGEST="$(docker image inspect --format="{{index .RepoDigests 0}}" "danielflook/terraform-github-actions-base:latest" | sed 's/.*@//')"
 
           docker build --tag dflook/terraform-github-actions \
+            --build-arg FETCH_CHECKSUMS=yes \
             --label org.opencontainers.image.created="$(date '+%Y-%m-%dT%H:%M:%S%z')" \
             --label org.opencontainers.image.source="https://github.com/${{ github.repository }}" \
             --label org.opencontainers.image.revision="${{ github.sha }}" \

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.9
 
@@ -20,6 +20,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r tests/requirements.txt
+          
+          gpg --recv-keys C874011F0AB405110D02105534365D9472D7468F \
+           && echo "C874011F0AB405110D02105534365D9472D7468F:6:" | gpg --import-ownertrust          
 
       - name: Run tests
         env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,4 +30,4 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: No
         run: |
-           PYTHONPATH=image/tools:image/src pytest tests
+           GNUPGHOME=$HOME/.gnupg PYTHONPATH=image/tools:image/src pytest tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -14,6 +14,7 @@ COPY src/ /tmp/src/
 COPY setup.py /tmp
 RUN pip install /tmp \
  && rm -rf /tmp/src /tmp/setup.py \
+ && TERRAFORM_BIN_CHECKSUM_DIR="/var/terraform" get-terraform-checksums \
  && TERRAFORM_BIN_CACHE_DIR="/var/terraform" TERRAFORM_BIN_CHECKSUM_DIR="/var/terraform" terraform-version 0.9.0 \
  && TERRAFORM_BIN_CACHE_DIR="/var/terraform" TERRAFORM_BIN_CHECKSUM_DIR="/var/terraform" terraform-version 0.12.0
 

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,11 +1,6 @@
 FROM danielflook/terraform-github-actions-base:latest
 
-RUN apt-get update  \
- && apt-get install --no-install-recommends -y \
-    gpg \
-    gpg-agent \
-    dirmngr \
- && rm -rf /var/lib/apt/lists/*
+ARG FETCH_CHECKSUMS
 
 RUN gpg --recv-keys C874011F0AB405110D02105534365D9472D7468F \
  && echo "C874011F0AB405110D02105534365D9472D7468F:6:" | gpg --import-ownertrust
@@ -13,9 +8,13 @@ RUN gpg --recv-keys C874011F0AB405110D02105534365D9472D7468F \
 COPY src/ /tmp/src/
 COPY setup.py /tmp
 RUN pip install /tmp \
- && rm -rf /tmp/src /tmp/setup.py \
- && TERRAFORM_BIN_CHECKSUM_DIR="/var/terraform" get-terraform-checksums \
- && TERRAFORM_BIN_CACHE_DIR="/var/terraform" TERRAFORM_BIN_CHECKSUM_DIR="/var/terraform" terraform-version 0.9.0 \
+ && rm -rf /tmp/src /tmp/setup.py
+
+RUN if [ "$FETCH_CHECKSUMS" = "yes" ]; then \
+  TERRAFORM_BIN_CHECKSUM_DIR="/var/terraform" get-terraform-checksums; \
+fi
+
+RUN TERRAFORM_BIN_CACHE_DIR="/var/terraform" TERRAFORM_BIN_CHECKSUM_DIR="/var/terraform" terraform-version 0.9.0 \
  && TERRAFORM_BIN_CACHE_DIR="/var/terraform" TERRAFORM_BIN_CHECKSUM_DIR="/var/terraform" terraform-version 0.12.0
 
 COPY entrypoints/ /entrypoints/

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,11 +1,21 @@
 FROM danielflook/terraform-github-actions-base:latest
 
+RUN apt-get update  \
+ && apt-get install --no-install-recommends -y \
+    gpg \
+    gpg-agent \
+    dirmngr \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN gpg --recv-keys C874011F0AB405110D02105534365D9472D7468F \
+ && echo "C874011F0AB405110D02105534365D9472D7468F:6:" | gpg --import-ownertrust
+
 COPY src/ /tmp/src/
 COPY setup.py /tmp
 RUN pip install /tmp \
  && rm -rf /tmp/src /tmp/setup.py \
- && TERRAFORM_BIN_DIR="/usr/local/bin" terraform-version 0.9.0 \
- && TERRAFORM_BIN_DIR="/usr/local/bin" terraform-version 0.12.0
+ && TERRAFORM_BIN_CACHE_DIR="/var/terraform" TERRAFORM_BIN_CHECKSUM_DIR="/var/terraform" terraform-version 0.9.0 \
+ && TERRAFORM_BIN_CACHE_DIR="/var/terraform" TERRAFORM_BIN_CHECKSUM_DIR="/var/terraform" terraform-version 0.12.0
 
 COPY entrypoints/ /entrypoints/
 COPY actions.sh /usr/local/actions.sh

--- a/image/actions.sh
+++ b/image/actions.sh
@@ -18,7 +18,7 @@ function debug() {
 function detect-terraform-version() {
     debug_cmd ls -la "/usr/local/bin"
     debug_cmd ls -la "$JOB_TMP_DIR/terraform-bin-dir"
-    TERRAFORM_BIN_DIR="/usr/local/bin:$JOB_TMP_DIR/terraform-bin-dir" terraform-version
+    TERRAFORM_BIN_CACHE_DIR="/var/terraform:$JOB_TMP_DIR/terraform-bin-dir" TERRAFORM_BIN_CHECKSUM_DIR="/var/terraform" terraform-version
     debug_cmd ls -la "$(which terraform)"
 
     local TF_VERSION

--- a/image/setup.py
+++ b/image/setup.py
@@ -14,7 +14,8 @@ setup(
             'github_pr_comment=github_pr_comment.__main__:main',
             'plan_summary=plan_summary.__main__:main',
             'terraform-cloud-state=terraform_cloud_state.__main__:main',
-            'remote-run-id=terraform_cloud_state.__main__:remote_run_id'
+            'remote-run-id=terraform_cloud_state.__main__:remote_run_id',
+            'get-terraform-checksums=terraform_version.get_checksums:main'
         ]
     },
     install_requires=[

--- a/image/src/github_actions/debug.py
+++ b/image/src/github_actions/debug.py
@@ -8,3 +8,9 @@ def debug(msg: str) -> None:
 
     for line in msg.splitlines():
         sys.stderr.write(f'::debug::{line}\n')
+
+def warning(msg: str) -> None:
+    """Add a warning message to the workflow log."""
+
+    for line in msg.splitlines():
+        sys.stderr.write(f'::warning::{line}\n')

--- a/image/src/terraform/download.py
+++ b/image/src/terraform/download.py
@@ -116,10 +116,14 @@ def verify_archive(version: Version, cache_dir: Path, archive_name: str, checksu
 
     :param version: The version of terraform to verify
     :param cache_dir: The directory the archive is in
+    :param archive_name: The name of the archive
     :param checksum_dir: The directory the checksum file can be found in
     """
 
     def get_checksum():
+        """
+        Get the checksum for specified archive from the checksums file
+        """
         for line in Path(checksum_dir, f'terraform_{version}_SHA256SUMS').read_bytes().splitlines():
             if archive_name.encode() in line:
                 return line + b'\n'

--- a/image/src/terraform/download.py
+++ b/image/src/terraform/download.py
@@ -65,6 +65,7 @@ def get_checksums(version: Version, checksum_dir: Path) -> Path:
 
     if not signature_path.exists():
         debug('Downloading signature')
+        os.makedirs(checksum_dir)
         urlretrieve(
             f'https://releases.hashicorp.com/terraform/{version}/terraform_{version}_SHA256SUMS.72D7468F.sig',
             signature_path
@@ -98,7 +99,7 @@ def download_archive(version: Version, cache_dir: Path) -> Tuple[Path, str]:
         return cache_dir, f'terraform_{version}_{get_platform()}_{get_arch()}.zip'
 
     debug('Downloading archive')
-
+    os.makedirs(cache_dir)
     urlretrieve(
         f'https://releases.hashicorp.com/terraform/{version}/terraform_{version}_{get_platform()}_{get_arch()}.zip',
         archive_path

--- a/image/src/terraform/download.py
+++ b/image/src/terraform/download.py
@@ -1,12 +1,15 @@
-"""Module for downloading terraform executables."""
+"""
+Module for downloading terraform executables.
+"""
 
 from __future__ import annotations
 
 import os.path
 import platform
+import subprocess
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Tuple
 from urllib.request import urlretrieve
 from zipfile import ZipFile
 
@@ -50,55 +53,124 @@ def get_arch() -> str:
     raise Exception(f'Unknown arch {a}')
 
 
-def download_version(version: Version, target_dir: Path) -> Path:
+def get_checksums(version: Version, checksum_dir: Path) -> Path:
     """
-    Download the executable for the given version of terraform.
+    Ensure we have the checksums in the checksum dir
 
-    The return value is the path to the executable
+    Checksum files must have a valid signature file
     """
 
-    terraform_path = Path(target_dir, 'terraform')
+    checksums_path = Path(checksum_dir, f'terraform_{version}_SHA256SUMS')
+    signature_path = Path(checksum_dir, f'terraform_{version}_SHA256SUMS.72D7468F.sig')
 
-    if os.path.exists(terraform_path):
-        return terraform_path
+    if not signature_path.exists():
+        debug('Downloading signature')
+        urlretrieve(
+            f'https://releases.hashicorp.com/terraform/{version}/terraform_{version}_SHA256SUMS.72D7468F.sig',
+            signature_path
+        )
 
-    debug(f'Downloading terraform {version}')
+    if not checksums_path.exists():
+        debug('Downloading checksums')
+        urlretrieve(
+            f'https://releases.hashicorp.com/terraform/{version}/terraform_{version}_SHA256SUMS',
+            checksums_path
+        )
 
-    local_filename, headers = urlretrieve(
-        f'https://releases.hashicorp.com/terraform/{version}/terraform_{version}_{get_platform()}_{get_arch()}.zip',
-        f'/tmp/terraform_{version}_linux_amd64.zip'
+    subprocess.run(
+        ['gpg', '--verify', signature_path, checksums_path],
+        check=True,
     )
 
-    with ZipFile(local_filename) as f:
-        f.extract('terraform', target_dir)
+    return checksums_path
 
-    os.chmod(terraform_path, 755)
 
-    return Path(os.path.abspath(terraform_path))
+def download_archive(version: Version, cache_dir: Path) -> Tuple[Path, str]:
+    """
+    Download the zip file for the given version of terraform.
+
+    The return value is the path to the zip file
+    """
+
+    archive_path = Path(cache_dir, f'terraform_{version}_{get_platform()}_{get_arch()}.zip')
+
+    if os.path.exists(archive_path):
+        return cache_dir, f'terraform_{version}_{get_platform()}_{get_arch()}.zip'
+
+    debug('Downloading archive')
+
+    urlretrieve(
+        f'https://releases.hashicorp.com/terraform/{version}/terraform_{version}_{get_platform()}_{get_arch()}.zip',
+        archive_path
+    )
+
+    return cache_dir, f'terraform_{version}_{get_platform()}_{get_arch()}.zip'
+
+
+def verify_archive(version: Version, cache_dir: Path, checksum_dir: Path) -> None:
+    """
+    Verify terraform zip archive
+
+    :param version: The version of terraform to verify
+    :param cache_dir: The directory the archive is in
+    :param checksum_dir: The directory the checksum file can be found in
+    """
+
+    subprocess.run(
+        ['shasum', '-a', '256', '-c', Path(checksum_dir, f'terraform_{version}_SHA256SUMS').absolute(), '--ignore-missing'],
+        check=True,
+        cwd=cache_dir
+    )
+
+
+def get_archive(version: Version, cache_dirs: list[Path]) -> Tuple[Path, str]:
+    """
+    Get the zip archive path for a terraform version
+    """
+
+    assert len(cache_dirs) > 0
+
+    for cache_dir in cache_dirs:
+
+        archive_path = Path(cache_dir, f'terraform_{version}_{get_platform()}_{get_arch()}.zip')
+        if archive_path.is_file():
+            return cache_dir, f'terraform_{version}_{get_platform()}_{get_arch()}.zip'
+
+    return download_archive(version, cache_dir)
 
 
 def get_executable(version: Version) -> Path:
     """
     Get the path to the specified terraform executable.
 
-    Executables may be in any of the directories in TERRAFORM_BIN_DIR.
-    If executable doesn't exist, download it to the last directory in TERRAFORM_BIN_DIR.
-    Cache dirs are specified in the TERRAFORM_BIN_DIR env var as ':' separated paths.
-    The default is .terraform-bin-dir in the current directory.
+    The directories in TERRAFORM_BIN_CACHE_DIR will be searched for the executable as a zip file.
+    If the executable doesn't exist it will be downloaded to the last directory in TERRAFORM_BIN_CACHE_DIR.
+    Cache dirs are specified in the TERRAFORM_BIN_CACHE_DIR env var as ':' separated paths.
+    These directories are untrusted and anything found there will be verified.
+
+    The TERRAFORM_BIN_CHECKSUM_DIR will be searched for checksum and signature files.
+    If they are not found they will be downloaded to TERRAFORM_BIN_CHECKSUM_DIR.
+
+    The default for both TERRAFORM_BIN_CACHE_DIR and TERRAFORM_BIN_CHECKSUM_DIR is .terraform-bin-dir in the current directory.
 
     The return value is the path to the executable
     """
 
-    cache_dirs = os.environ.get('TERRAFORM_BIN_DIR', '.terraform-bin-dir').split(':')
+    cache_dirs = [Path(p) for p in os.environ.get('TERRAFORM_BIN_CACHE_DIR', '.terraform-bin-dir').split(':')]
+    checksum_dir = Path(os.environ.get('TERRAFORM_BIN_CHECKSUM_DIR', '.terraform-bin-dir'))
 
-    download_dir = None
+    get_checksums(version, checksum_dir)
+    cache_dir, archive_name = get_archive(version, cache_dirs)
+    verify_archive(version, cache_dir, checksum_dir)
 
-    for tf_dir in cache_dirs:
-        download_dir = Path(tf_dir, f'terraform_{version}')
-        terraform_path = os.path.join(download_dir, 'terraform')
-        if os.path.isfile(terraform_path):
-            return Path(os.path.abspath(terraform_path))
+    executable_dir = os.environ.get('STEP_TEMP_DIR', f'/tmp/terraform_{version}')
 
-    assert download_dir is not None
+    Path(executable_dir, 'terraform').unlink(missing_ok=True)
+    with ZipFile(Path(cache_dir, archive_name)) as f:
+        f.extract('terraform', executable_dir)
 
-    return download_version(version, download_dir)
+    executable_path = Path(executable_dir, 'terraform')
+
+    os.chmod(executable_path, 755)
+
+    return executable_path

--- a/image/src/terraform/download.py
+++ b/image/src/terraform/download.py
@@ -65,7 +65,7 @@ def get_checksums(version: Version, checksum_dir: Path) -> Path:
 
     if not signature_path.exists():
         debug('Downloading signature')
-        os.makedirs(checksum_dir)
+        os.makedirs(checksum_dir, exist_ok=True)
         urlretrieve(
             f'https://releases.hashicorp.com/terraform/{version}/terraform_{version}_SHA256SUMS.72D7468F.sig',
             signature_path
@@ -99,7 +99,7 @@ def download_archive(version: Version, cache_dir: Path) -> Tuple[Path, str]:
         return cache_dir, f'terraform_{version}_{get_platform()}_{get_arch()}.zip'
 
     debug('Downloading archive')
-    os.makedirs(cache_dir)
+    os.makedirs(cache_dir, exist_ok=True)
     urlretrieve(
         f'https://releases.hashicorp.com/terraform/{version}/terraform_{version}_{get_platform()}_{get_arch()}.zip',
         archive_path

--- a/image/src/terraform/download.py
+++ b/image/src/terraform/download.py
@@ -66,16 +66,18 @@ def get_checksums(version: Version, checksum_dir: Path) -> Path:
     os.makedirs(checksum_dir, exist_ok=True)
 
     if not signature_path.exists():
-        debug('Downloading signature')
+        signature_url = f'https://releases.hashicorp.com/terraform/{version}/terraform_{version}_SHA256SUMS.72D7468F.sig'
+        debug(f'Downloading signature from {signature_url}')
         urlretrieve(
-            f'https://releases.hashicorp.com/terraform/{version}/terraform_{version}_SHA256SUMS.72D7468F.sig',
+            signature_url,
             signature_path
         )
 
     if not checksums_path.exists():
-        debug('Downloading checksums')
+        checksum_url = f'https://releases.hashicorp.com/terraform/{version}/terraform_{version}_SHA256SUMS'
+        debug(f'Downloading checksums from {checksum_url}')
         urlretrieve(
-            f'https://releases.hashicorp.com/terraform/{version}/terraform_{version}_SHA256SUMS',
+            checksum_url,
             checksums_path
         )
 
@@ -100,10 +102,11 @@ def download_archive(version: Version, cache_dir: Path) -> Tuple[Path, str]:
     if os.path.exists(archive_path):
         return cache_dir, f'terraform_{version}_{get_platform()}_{get_arch()}.zip'
 
-    debug('Downloading archive')
+    archive_url = f'https://releases.hashicorp.com/terraform/{version}/terraform_{version}_{get_platform()}_{get_arch()}.zip'
+    debug(f'Downloading archive from {archive_url}')
     os.makedirs(cache_dir, exist_ok=True)
     urlretrieve(
-        f'https://releases.hashicorp.com/terraform/{version}/terraform_{version}_{get_platform()}_{get_arch()}.zip',
+        archive_url,
         archive_path
     )
 

--- a/image/src/terraform/download.py
+++ b/image/src/terraform/download.py
@@ -81,7 +81,7 @@ def get_checksums(version: Version, checksum_dir: Path) -> Path:
     subprocess.run(
         ['gpg', '--verify', signature_path, checksums_path],
         check=True,
-        env=os.environ | {'GNUPGHOME': '/root/.gnupg'}
+        env={'GNUPGHOME': '/root/.gnupg'} | os.environ
     )
 
     return checksums_path

--- a/image/src/terraform/download.py
+++ b/image/src/terraform/download.py
@@ -81,6 +81,7 @@ def get_checksums(version: Version, checksum_dir: Path) -> Path:
     subprocess.run(
         ['gpg', '--verify', signature_path, checksums_path],
         check=True,
+        env=os.environ | {'GNUPGHOME': '/root/.gnupg'}
     )
 
     return checksums_path

--- a/image/src/terraform/versions.py
+++ b/image/src/terraform/versions.py
@@ -23,7 +23,7 @@ class Version:
 
     def __init__(self, version: str):
 
-        match = re.match(r'(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<pre_release>[\d\w]+))?', version)
+        match = re.match(r'(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<pre_release>[\d\w-]+))?', version)
         if not match:
             raise ValueError(f'Not a valid version {version}')
 
@@ -214,7 +214,7 @@ def get_terraform_versions() -> Iterable[Version]:
     response = session.get('https://releases.hashicorp.com/terraform/')
     response.raise_for_status()
 
-    version_regex = re.compile(br'/(\d+\.\d+\.\d+(-[\d\w]+)?)')
+    version_regex = re.compile(br'/(\d+\.\d+\.\d+(-[\d\w-]+)?)')
 
     for version in version_regex.finditer(response.content):
         yield Version(version.group(1).decode())

--- a/image/src/terraform_version/__main__.py
+++ b/image/src/terraform_version/__main__.py
@@ -92,8 +92,6 @@ def switch(version: Version) -> None:
     The version will be downloaded if it doesn't already exist.
     """
 
-    sys.stdout.write(f'Switching to Terraform v{version}\n')
-
     target_path = get_executable(version)
 
     link_path = '/usr/local/bin/terraform'
@@ -101,7 +99,7 @@ def switch(version: Version) -> None:
         os.remove(link_path)
 
     os.symlink(target_path, link_path)
-
+    sys.stdout.write(f'Switched to Terraform v{version}\n')
 
 def main() -> None:
     """Entrypoint for terraform-version."""

--- a/image/src/terraform_version/get_checksums.py
+++ b/image/src/terraform_version/get_checksums.py
@@ -1,0 +1,17 @@
+import os
+import sys
+from pathlib import Path
+
+from terraform.download import get_checksums
+from terraform.versions import get_terraform_versions
+
+
+def main() -> None:
+
+    checksum_dir = Path(os.environ.get('TERRAFORM_BIN_CHECKSUM_DIR', '.terraform-bin-dir'))
+
+    for version in get_terraform_versions():
+        if version.pre_release:
+            continue
+        sys.stdout.write(f'Getting checksums for {version}\n')
+        get_checksums(version, checksum_dir)

--- a/tests/terraform_version/test_latest.py
+++ b/tests/terraform_version/test_latest.py
@@ -10,7 +10,8 @@ def test_latest():
         Version('1.1.9'),
         Version('1.1.7'),
         Version('1.1.0-alpha20210811'),
-        Version('1.2.0-alpha20225555')
+        Version('1.2.0-alpha20225555'),
+        Version('1.2.0-alpha-20220328')
     ]
 
     assert earliest_version(versions) == Version('0.13.6-alpha-23')

--- a/tests/terraform_version/test_remote_state_s3.py
+++ b/tests/terraform_version/test_remote_state_s3.py
@@ -5,8 +5,7 @@ import subprocess
 import hcl2
 import pytest
 
-from terraform.download import download_version, get_executable
-from terraform.module import load_module
+from terraform.download import get_executable
 from terraform.versions import Version, apply_constraints
 from terraform_version.remote_state import try_guess_state_version, get_backend_constraints
 

--- a/tests/test_terraform_checksums.py
+++ b/tests/test_terraform_checksums.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+from subprocess import CalledProcessError
+from urllib.error import HTTPError
+
+from terraform.versions import Version
+from terraform.download import get_checksums, download_archive, verify_archive
+
+import tempfile
+import os
+
+def test_get_checksums():
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        # Assume correct signature
+        checksums_path = get_checksums(Version('0.9.7'), tempdir)
+        assert checksums_path.is_file()
+
+        # tamper with the signature
+        os.rename(Path(tempdir, 'terraform_0.9.7_SHA256SUMS.72D7468F.sig'),
+                  Path(tempdir, 'terraform_0.11.8_SHA256SUMS.72D7468F.sig'))
+        try:
+            get_checksums(Version('0.11.8'), tempdir)
+        except CalledProcessError:
+            pass
+        else:
+            raise AssertionError('No exception was raised for invalid signature')
+
+        # No such signature
+        try:
+            get_checksums(Version('1.1.100'), tempdir)
+        except HTTPError:
+            pass
+        else:
+            raise AssertionError('No exception was raised for no signature found')
+
+def test_verify_archive():
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        # Assume correct checksum
+        version = Version('0.9.7')
+        get_checksums(version, tempdir)
+        archive_dir, archive_name = download_archive(version, tempdir)
+        verify_archive(version, archive_dir, archive_name, tempdir)
+
+        # No checksum found
+        version = Version('0.11.8')
+        os.rename(Path(tempdir, 'terraform_0.9.7_SHA256SUMS'),
+                  Path(tempdir, 'terraform_0.11.8_SHA256SUMS'))
+        archive_dir, archive_name = download_archive(version, tempdir)
+
+        try:
+            verify_archive(version, archive_dir, archive_name, tempdir)
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError('No exception was raised for checksum not found')
+
+        # Incorrect checksum
+        Path(tempdir, 'terraform_0.11.8_SHA256SUMS').write_bytes(
+            b'53f7bbde44262a32765731553a61dc8e103d49a036c85eacc3f2bdbe9ecf7777  ' + archive_name.encode()
+        )
+
+        try:
+            verify_archive(version, archive_dir, archive_name, tempdir)
+        except CalledProcessError:
+            pass
+        else:
+            raise AssertionError('No exception was raised for incorrect checksum')


### PR DESCRIPTION
Check terraform executables for integrity before use - the checksum file must be correctly signed.
This includes any archive cached by a terraform-github-actions Action in a previous step which could have been tampered with by another job on a self-hosted runner.