### PR TITLE
Use graphql to get current username

### DIFF
--- a/.github/workflows/test-apply.yaml
+++ b/.github/workflows/test-apply.yaml
@@ -684,6 +684,50 @@ jobs:
             exit 1
           fi
 
+  apply_fine_grained_pat:
+    runs-on: ubuntu-latest
+    name: Apply using a fine grained personal access token
+    env:
+      GITHUB_TOKEN: ${{ secrets.FINE_PAT_GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Plan
+        uses: ./terraform-plan
+        with:
+          label: test-apply apply_fine_grained_pat
+          path: tests/workflows/test-apply/changes
+
+      - name: Apply
+        uses: ./terraform-apply
+        id: output
+        with:
+          label: test-apply apply_fine_grained_pat
+          path: tests/workflows/test-apply/changes
+
+      - name: Verify outputs
+        run: |
+          if [[ "${{ steps.output.outputs.output_string }}" != "the_string" ]]; then
+            echo "::error:: output s not set correctly"
+            exit 1
+          fi
+
+          if [[ $(jq -r .output_changes.output_string.actions[0] "${{ steps.output.outputs.json_plan_path }}") != "create" ]]; then
+            echo "::error:: json_plan_path not set correctly"
+            exit 1
+          fi
+
+          if ! grep -q "Terraform will perform the following actions" '${{ steps.output.outputs.text_plan_path }}'; then
+            echo "::error:: text_plan_path not set correctly"
+            exit 1
+          fi
+
+          if [[ -n "${{ steps.output.outputs.run_id }}" ]]; then
+            echo "::error:: run_id should not be set"
+            exit 1
+          fi
+
   apply_vars:
     runs-on: ubuntu-latest
     name: Apply approved changes with deprecated vars

--- a/.github/workflows/test-apply.yaml
+++ b/.github/workflows/test-apply.yaml
@@ -728,6 +728,51 @@ jobs:
             exit 1
           fi
 
+  apply_terraform_actions_github_token:
+    runs-on: ubuntu-latest
+    name: Apply using a token in TERRAFORM_ACTIONS_GITHUB_TOKEN
+    env:
+      GITHUB_TOKEN: No
+      TERRAFORM_ACTIONS_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Plan
+        uses: ./terraform-plan
+        with:
+          label: test-apply apply_terraform_actions_github_token
+          path: tests/workflows/test-apply/changes
+
+      - name: Apply
+        uses: ./terraform-apply
+        id: output
+        with:
+          label: test-apply apply_terraform_actions_github_token
+          path: tests/workflows/test-apply/changes
+
+      - name: Verify outputs
+        run: |
+          if [[ "${{ steps.output.outputs.output_string }}" != "the_string" ]]; then
+            echo "::error:: output s not set correctly"
+            exit 1
+          fi
+
+          if [[ $(jq -r .output_changes.output_string.actions[0] "${{ steps.output.outputs.json_plan_path }}") != "create" ]]; then
+            echo "::error:: json_plan_path not set correctly"
+            exit 1
+          fi
+
+          if ! grep -q "Terraform will perform the following actions" '${{ steps.output.outputs.text_plan_path }}'; then
+            echo "::error:: text_plan_path not set correctly"
+            exit 1
+          fi
+
+          if [[ -n "${{ steps.output.outputs.run_id }}" ]]; then
+            echo "::error:: run_id should not be set"
+            exit 1
+          fi
+
   apply_vars:
     runs-on: ubuntu-latest
     name: Apply approved changes with deprecated vars

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,6 +28,6 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          GITHUB_TOKEN: No
+          TERRAFORM_ACTIONS_GITHUB_TOKEN: No
         run: |
            GNUPGHOME=$HOME/.gnupg PYTHONPATH=image/tools:image/src pytest tests

--- a/image/actions.sh
+++ b/image/actions.sh
@@ -102,6 +102,12 @@ function setup() {
 
     detect-tfmask
 
+    if [[ ! -v TERRAFORM_ACTIONS_GITHUB_TOKEN ]]; then
+      if [[ -v GITHUB_TOKEN ]]; then
+        export TERRAFORM_ACTIONS_GITHUB_TOKEN="$GITHUB_TOKEN"
+      fi
+    fi
+
     execute_run_commands
 }
 

--- a/image/entrypoints/apply.sh
+++ b/image/entrypoints/apply.sh
@@ -10,7 +10,7 @@ set-plan-args
 
 PLAN_OUT="$STEP_TMP_DIR/plan.out"
 
-if [[ -v GITHUB_TOKEN ]]; then
+if [[ -v TERRAFORM_ACTIONS_GITHUB_TOKEN ]]; then
     update_status ":orange_circle: Applying plan in $(job_markdown_ref)"
 fi
 
@@ -111,7 +111,7 @@ else
         exit 1
     fi
 
-    if [[ ! -v GITHUB_TOKEN ]]; then
+    if [[ ! -v TERRAFORM_ACTIONS_GITHUB_TOKEN ]]; then
         echo "GITHUB_TOKEN environment variable must be set to get plan approval from a PR"
         echo "Either set the GITHUB_TOKEN environment variable or automatically approve by setting the auto_approve input to 'true'"
         echo "See https://github.com/dflook/terraform-github-actions/ for details."

--- a/image/entrypoints/plan.sh
+++ b/image/entrypoints/plan.sh
@@ -40,7 +40,7 @@ fi
 if [[ "$GITHUB_EVENT_NAME" == "pull_request" || "$GITHUB_EVENT_NAME" == "issue_comment" || "$GITHUB_EVENT_NAME" == "pull_request_review_comment" || "$GITHUB_EVENT_NAME" == "pull_request_target" || "$GITHUB_EVENT_NAME" == "pull_request_review" ]]; then
     if [[ "$INPUT_ADD_GITHUB_COMMENT" == "true" || "$INPUT_ADD_GITHUB_COMMENT" == "changes-only" ]]; then
 
-        if [[ ! -v GITHUB_TOKEN ]]; then
+        if [[ ! -v TERRAFORM_ACTIONS_GITHUB_TOKEN ]]; then
             echo "GITHUB_TOKEN environment variable must be set to add GitHub PR comments"
             echo "Either set the GITHUB_TOKEN environment variable, or disable by setting the add_github_comment input to 'false'"
             echo "See https://github.com/dflook/terraform-github-actions/ for details."

--- a/image/src/github_actions/env.py
+++ b/image/src/github_actions/env.py
@@ -12,6 +12,7 @@ class ActionsEnv(TypedDict):
     TERRAFORM_PRE_RUN: str
     TERRAFORM_HTTP_CREDENTIALS: str
     TERRAFORM_VERSION: str
+    TERRAFORM_ACTIONS_GITHUB_TOKEN: str
 
 
 class GithubEnv(TypedDict):

--- a/image/src/github_pr_comment/__main__.py
+++ b/image/src/github_pr_comment/__main__.py
@@ -143,24 +143,48 @@ def create_summary(plan: Plan) -> Optional[str]:
 
 
 def current_user(actions_env: GithubEnv) -> str:
-    token_hash = hashlib.sha256(actions_env['GITHUB_TOKEN'].encode()).hexdigest()
+    token_hash = hashlib.sha256(f'dflook/terraform-github-actions/{actions_env["GITHUB_TOKEN"]}'.encode()).hexdigest()
     cache_key = f'token-cache/{token_hash}'
+
+    def graphql() -> Optional[str]:
+        response = github.post(f'{actions_env["GITHUB_API_URL"]}/graphql', json={
+            'query': "query { viewer { login } }"
+        })
+
+        if response.ok:
+            try:
+                debug(f'graphql response: {response.content}')
+                return response.json()['data']['viewer']['login']
+            except Exception as e:
+                pass
+
+        debug('Failed to get current user from graphql')
+
+    def rest() -> Optional[str]:
+        response = github.get(f'{actions_env["GITHUB_API_URL"]}/user')
+
+        if response.ok:
+            user = response.json()
+            debug(f'rest response: {json.dumps(user)}')
+
+            return user['login']
 
     if cache_key in job_cache:
         username = job_cache[cache_key]
     else:
-        response = github.get(f'{actions_env["GITHUB_API_URL"]}/user')
-        if response.status_code != 403:
-            user = response.json()
-            debug(json.dumps(user))
 
-            username = user['login']
-        else:
-            # Assume this is the github actions app token
-            username = 'github-actions[bot]'
+        # Not all tokens can be used with graphql
+        # There is also no rest endpoint that can get the current login for app tokens :(
+        # Try graphql first, then fallback to rest (e.g. for fine grained PATs)
+
+        username = graphql() or rest()
+
+        if username is None:
+            raise Exception('Unable to get username for the github token')
 
         job_cache[cache_key] = username
 
+    debug(f'token username is {username}')
     return username
 
 

--- a/image/src/github_pr_comment/__main__.py
+++ b/image/src/github_pr_comment/__main__.py
@@ -30,8 +30,8 @@ job_cache = ActionsCache(Path(os.environ.get('JOB_TMP_DIR', '.')), 'job_cache')
 step_cache = ActionsCache(Path(os.environ.get('STEP_TMP_DIR', '.')), 'step_cache')
 
 env = cast(GithubEnv, os.environ)
-
-github = GithubApi(env.get('GITHUB_API_URL', 'https://api.github.com'), env['GITHUB_TOKEN'])
+github_token = env['TERRAFORM_ACTIONS_GITHUB_TOKEN']
+github = GithubApi(env.get('GITHUB_API_URL', 'https://api.github.com'), github_token)
 
 def job_markdown_ref() -> str:
     return f'[{os.environ["GITHUB_WORKFLOW"]} #{os.environ["GITHUB_RUN_NUMBER"]}]({os.environ["GITHUB_SERVER_URL"]}/{os.environ["GITHUB_REPOSITORY"]}/actions/runs/{os.environ["GITHUB_RUN_ID"]})'
@@ -143,7 +143,7 @@ def create_summary(plan: Plan) -> Optional[str]:
 
 
 def current_user(actions_env: GithubEnv) -> str:
-    token_hash = hashlib.sha256(f'dflook/terraform-github-actions/{actions_env["GITHUB_TOKEN"]}'.encode()).hexdigest()
+    token_hash = hashlib.sha256(f'dflook/terraform-github-actions/{github_token}'.encode()).hexdigest()
     cache_key = f'token-cache/{token_hash}'
 
     def graphql() -> Optional[str]:

--- a/image/tools/github_comment_react.py
+++ b/image/tools/github_comment_react.py
@@ -22,6 +22,7 @@ class GitHubActionsEnv(TypedDict):
     GITHUB_EVENT_NAME: str
     GITHUB_REPOSITORY: str
     GITHUB_SHA: str
+    TERRAFORM_ACTIONS_GITHUB_TOKEN: str
 
 
 job_tmp_dir = os.environ.get('JOB_TMP_DIR', '.')
@@ -35,7 +36,7 @@ def github_session(github_env: GitHubActionsEnv) -> requests.Session:
     A request session that is configured for the github API
     """
     session = requests.Session()
-    session.headers['authorization'] = f'token {github_env["GITHUB_TOKEN"]}'
+    session.headers['authorization'] = f'token {github_env["TERRAFORM_ACTIONS_GITHUB_TOKEN"]}'
     session.headers['user-agent'] = 'terraform-github-actions'
     session.headers['accept'] = 'application/vnd.github.v3+json'
     return session
@@ -108,7 +109,7 @@ def main() -> None:
 
 
 if __name__ == '__main__':
-    if 'GITHUB_TOKEN' not in env:
+    if 'TERRAFORM_ACTIONS_GITHUB_TOKEN' not in env:
         exit(0)
     github = github_session(env)
     main()

--- a/terraform-apply/README.md
+++ b/terraform-apply/README.md
@@ -251,7 +251,7 @@ These input values must be the same as any `terraform-plan` for the same configu
 * `GITHUB_TOKEN`
 
   The GitHub authorization token to use to fetch an approved plan from a PR. 
-  This must belong to the same user as the token used by the terraform-plan action.
+  This must belong to the same user/app as the token used by the terraform-plan action.
   The token provided by GitHub Actions can be used - it can be passed by
   using the `${{ secrets.GITHUB_TOKEN }}` expression, e.g.
 
@@ -264,11 +264,22 @@ These input values must be the same as any `terraform-plan` for the same configu
   The minimum permissions are `pull-requests: write`.
   It will also likely need `contents: read` so the job can checkout the repo.
 
+  You can also use any other App token that has `pull-requests: write` permission.
+
   You can use a fine-grained Personal Access Token which has repository permissions:
   - Read access to metadata
   - Read and Write access to pull requests
 
   You can also use a classic Personal Access Token which has the `repo` scope.
+
+  - Type: string
+  - Optional
+
+* `TERRAFORM_ACTIONS_GITHUB_TOKEN`
+
+  When this is set it is used instead of `GITHUB_TOKEN`, with the same behaviour.
+  The GitHub terraform provider also uses the `GITHUB_TOKEN` so this can be used to
+  make the github actions and the terraform provider use different tokens.
 
   - Type: string
   - Optional

--- a/terraform-apply/README.md
+++ b/terraform-apply/README.md
@@ -250,7 +250,8 @@ These input values must be the same as any `terraform-plan` for the same configu
 
 * `GITHUB_TOKEN`
 
-  The GitHub authorization token to use to fetch an approved plan from a PR.
+  The GitHub authorization token to use to fetch an approved plan from a PR. 
+  This must belong to the same user as the token used by the terraform-plan action.
   The token provided by GitHub Actions can be used - it can be passed by
   using the `${{ secrets.GITHUB_TOKEN }}` expression, e.g.
 
@@ -263,8 +264,11 @@ These input values must be the same as any `terraform-plan` for the same configu
   The minimum permissions are `pull-requests: write`.
   It will also likely need `contents: read` so the job can checkout the repo.
 
-  You can also use a Personal Access Token which has the `repo` scope.
-  This must belong to the same user as the token used by the terraform-plan action
+  You can use a fine-grained Personal Access Token which has repository permissions:
+  - Read access to metadata
+  - Read and Write access to pull requests
+
+  You can also use a classic Personal Access Token which has the `repo` scope.
 
   - Type: string
   - Optional

--- a/terraform-plan/README.md
+++ b/terraform-plan/README.md
@@ -201,12 +201,24 @@ The [dflook/terraform-apply](https://github.com/dflook/terraform-github-actions/
   The minimum permissions are `pull-requests: write`.
   It will also likely need `contents: read` so the job can checkout the repo.
 
+  You can also use any other App token that has `pull-requests: write` permission.
+
   You can use a fine-grained Personal Access Token which has repository permissions:
   - Read access to metadata
   - Read and Write access to pull requests
 
   You can also use a classic Personal Access Token which has the `repo` scope.
-  The GitHub user that owns the PAT will be the PR comment author.
+
+  The GitHub user or app that owns the token will be the PR comment author.
+
+  - Type: string
+  - Optional
+
+* `TERRAFORM_ACTIONS_GITHUB_TOKEN`
+
+  When this is set it is used instead of `GITHUB_TOKEN`, with the same behaviour.
+  The GitHub terraform provider also uses the `GITHUB_TOKEN` environment variable, 
+  so this can be used to make the github actions and the terraform provider use different tokens.
 
   - Type: string
   - Optional

--- a/terraform-plan/README.md
+++ b/terraform-plan/README.md
@@ -201,7 +201,11 @@ The [dflook/terraform-apply](https://github.com/dflook/terraform-github-actions/
   The minimum permissions are `pull-requests: write`.
   It will also likely need `contents: read` so the job can checkout the repo.
 
-  You can also use a Personal Access Token which has the `repo` scope.
+  You can use a fine-grained Personal Access Token which has repository permissions:
+  - Read access to metadata
+  - Read and Write access to pull requests
+
+  You can also use a classic Personal Access Token which has the `repo` scope.
   The GitHub user that owns the PAT will be the PR comment author.
 
   - Type: string


### PR DESCRIPTION
This will work with app tokens but will also fail for some other tokens, so fall back to rest.

Uses the TERRAFORM_ACTIONS_GITHUB_TOKEN environment variable instead of GITHUB_TOKEN if it is set.
This is because the github terraform provider uses the token in GITHUB_TOKEN, so this allows the terraform provider and the github actions to use separate tokens.