### PR TITLE
[terraform-fmt] Explicitly call out `-recursive` is set in README

### DIFF
--- a/terraform-fmt/README.md
+++ b/terraform-fmt/README.md
@@ -2,7 +2,7 @@
 
 This is one of a suite of terraform related actions - find them at [dflook/terraform-github-actions](https://github.com/dflook/terraform-github-actions).
 
-This action uses the `terraform fmt` command to reformat files in a directory into a canonical format.
+This action uses the `terraform fmt -recursive` command to reformat files in a directory into a canonical format.
 
 ## Inputs
 


### PR DESCRIPTION
The `fmt` command has `-recursive` set in [fmt.sh](https://github.com/dflook/terraform-github-actions/blob/main/image/entrypoints/fmt.sh#L9) but the README doesn't mention this, potentially leading to unexpected behavior. 

Let's explicitly call this out somewhere in the `fmt` README