### PR TITLE
Fix lint example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ name: Lint
 
 on:
   push:
-    branches:
-      - '!main'
+    branches-ignore:
+      - main
 
 jobs:
   validate:


### PR DESCRIPTION
The proper way is to use `branches-ignore` instead of `branches` + `!` when you are only excluding things.