### PR TITLE
Install AWS cli in base image

### DIFF
--- a/image/Dockerfile-base
+++ b/image/Dockerfile-base
@@ -29,6 +29,7 @@ RUN apt-get update  \
     python3-pip \
     wget \
     gpg \
+    awscli \
     gpg-agent \
     dirmngr \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Hello,
My terraform uses aws cli to get token from EKS, could you please also add the aws cli to the baseimage?