### PR TITLE
Prefer GITHUB_GRAPHQL_URL environment variable

### DIFF
--- a/image/src/github_actions/env.py
+++ b/image/src/github_actions/env.py
@@ -18,6 +18,7 @@ class ActionsEnv(TypedDict):
 class GithubEnv(TypedDict):
     """Environment variables that are set by the actions runner."""
     GITHUB_API_URL: str
+    GITHUB_GRAPHQL_URL: str
     GITHUB_TOKEN: str
     GITHUB_EVENT_PATH: str
     GITHUB_EVENT_NAME: str

--- a/image/src/github_pr_comment/__main__.py
+++ b/image/src/github_pr_comment/__main__.py
@@ -212,13 +212,15 @@ def current_user(actions_env: GithubEnv) -> str:
     cache_key = f'token-cache/{token_hash}'
 
     def graphql() -> Optional[str]:
-        response = github.post(f'{actions_env["GITHUB_API_URL"]}/graphql', json={
+        graphql_url = actions_env.get('GITHUB_GRAPHQL_URL', f'{actions_env["GITHUB_API_URL"]}/graphql')
+
+        response = github.post(graphql_url, json={
             'query': "query { viewer { login } }"
         })
+        debug(f'graphql response: {response.content}')
 
         if response.ok:
             try:
-                debug(f'graphql response: {response.content}')
                 return response.json()['data']['viewer']['login']
             except Exception as e:
                 pass
@@ -227,10 +229,10 @@ def current_user(actions_env: GithubEnv) -> str:
 
     def rest() -> Optional[str]:
         response = github.get(f'{actions_env["GITHUB_API_URL"]}/user')
+        debug(f'rest response: {response.content}')
 
         if response.ok:
             user = response.json()
-            debug(f'rest response: {json.dumps(user)}')
 
             return user['login']
 


### PR DESCRIPTION
GITHUB_API_URL seems to include a rest specific path prefix in GHES, so can't be used for graphql requests