### PR TITLE
Update dependencies for terraform-fmt

### DIFF
--- a/terraform-fmt/README.md
+++ b/terraform-fmt/README.md
@@ -101,7 +101,7 @@ jobs:
           path: my-terraform-config
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v2
+        uses: peter-evans/create-pull-request@v5
         with:
           commit-message: terraform fmt
           title: Reformat terraform files


### PR DESCRIPTION
updated to latest version of `peter-evans/create-pull-request` to avoid security issues. 

v2 is using `set-env` and `set-path` which has been deprecated starting from 2.273.5
<img width="1051" alt="Screenshot 2023-07-17 at 13 06 01" src="https://github.com/dflook/terraform-github-actions/assets/34598860/b52b6f00-d562-4d25-8fe8-2d941d0c0ddd">

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/ 
