### PR TITLE
Fallback to github-actions bot user

### DIFF
--- a/image/src/github_pr_comment/__main__.py
+++ b/image/src/github_pr_comment/__main__.py
@@ -247,7 +247,8 @@ def current_user(actions_env: GithubEnv) -> str:
         username = graphql() or rest()
 
         if username is None:
-            raise Exception('Unable to get username for the github token')
+            debug('Unable to get username for the github token')
+            username = 'github-actions[bot]'
 
         job_cache[cache_key] = username
 


### PR DESCRIPTION
If we are unable to find the login for the current token, fallback to `github-actions[bot]`. 

Failure to get the user for the github-runner token has been seen with GHES. This will allow PR comments to be created anyway - and if the token does belong the the github-actions app everything will work as it should.

If the token does not belong to the github-actions app and github still won't tell us who it belongs to, then applies will fail to find the comment. But there's not much we can do about that.