### PR TITLE
Fix exception logging in loading phase

### DIFF
--- a/image/src/terraform/hcl.py
+++ b/image/src/terraform/hcl.py
@@ -15,7 +15,7 @@ def try_load(path: Path) -> dict:
         with open(path) as f:
             return hcl2.load(f)
     except Exception as e:
-        debug(e)
+        debug(str(e))
         return {}
 
 


### PR DESCRIPTION
Quick fix:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/dist-packages/lark/parsers/lalr_parser_state.py", line 77, in feed_token
    action, arg = states[state][token.type]
KeyError: '__ANON_3'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.9/dist-packages/terraform/hcl.py", line 16, in try_load
    return hcl2.load(f)
  File "/usr/local/lib/python3.9/dist-packages/hcl2/api.py", line 14, in load
    return loads(file.read(), with_meta=with_meta)
  File "/usr/local/lib/python3.9/dist-packages/hcl2/api.py", line 27, in loads
    tree = hcl2.parse(text + "\n")
  File "/usr/local/lib/python3.9/dist-packages/lark/lark.py", line 658, in parse
    return self.parser.parse(text, start=start, on_error=on_error)
  File "/usr/local/lib/python3.9/dist-packages/lark/parser_frontends.py", line 104, in parse
    return self.parser.parse(stream, chosen_start, **kw)
  File "/usr/local/lib/python3.9/dist-packages/lark/parsers/lalr_parser.py", line 42, in parse
    return self.parser.parse(lexer, start)
  File "/usr/local/lib/python3.9/dist-packages/lark/parsers/lalr_parser.py", line 88, in parse
    return self.parse_from_state(parser_state)
  File "/usr/local/lib/python3.9/dist-packages/lark/parsers/lalr_parser.py", line 111, in parse_from_state
    raise e
  File "/usr/local/lib/python3.9/dist-packages/lark/parsers/lalr_parser.py", line 102, in parse_from_state
    state.feed_token(token)
  File "/usr/local/lib/python3.9/dist-packages/lark/parsers/lalr_parser_state.py", line 80, in feed_token
    raise UnexpectedToken(token, expected, state=self, interactive_parser=None)
lark.exceptions.UnexpectedToken: Unexpected token Token('__ANON_3', 'payload_format_version') at line 134, column 7.
Expected one of: 
	* PLUS
	* __ANON_2
	* __ANON_6
	* MINUS
	* __ANON_9
	* __ANON_7
	* __ANON_1
	* LESSTHAN
	* SLASH
	* MORETHAN
	* __ANON_8
	* RBRACE
	* __ANON_0
	* __ANON_4
	* __ANON_5
	* STAR
	* PERCENT
	* QMARK
	* COMMA


During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.9/dist-packages/terraform/hcl.py", line 61, in <module>
    try_load(Path(sys.argv[1]))
  File "/usr/local/lib/python3.9/dist-packages/terraform/hcl.py", line 18, in try_load
    debug(e)
  File "/usr/local/lib/python3.9/dist-packages/github_actions/debug.py", line 9, in debug
    for line in msg.splitlines():
AttributeError: 'UnexpectedToken' object has no attribute 'splitlines'
```