### PR TITLE
Isolate credentials inside container

### DIFF
--- a/.github/workflows/test-http.yaml
+++ b/.github/workflows/test-http.yaml
@@ -117,6 +117,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Create dummy credential file
+        run: |
+          mkdir -p ${{ runner.temp }}/_github_home
+          cp tests/workflows/test-http/http-module/netrc ${{ runner.temp }}/_github_home/.netrc
+          ls -la ${{ runner.temp }}
+
       - name: Apply
         uses: ./terraform-apply
         id: output
@@ -130,6 +136,9 @@ jobs:
             echo "::error:: output not set correctly"
             exit 1
           fi
+          
+          # Check the credential file is as before
+          diff tests/workflows/test-http/http-module/netrc ${{ runner.temp }}/_github_home/.netrc
 
   http_no_credentials:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-registry.yaml
+++ b/.github/workflows/test-registry.yaml
@@ -14,6 +14,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Create dummy credential file
+        run: |
+          mkdir -p ${{ runner.temp }}/_github_home
+          cp tests/workflows/test-registry/terraformrc ${{ runner.temp }}/_github_home/.terraformrc
+          ls -la ${{ runner.temp }}
+
       - name: Plan
         uses: ./terraform-plan
         env:
@@ -37,6 +43,9 @@ jobs:
             echo "::error:: output not set correctly"
             exit 1
           fi
+          
+          # Check that terraformrc is as before
+          diff tests/workflows/test-registry/terraformrc ${{ runner.temp }}/_github_home/.terraformrc
 
   multiple_registry_module:
     runs-on: ubuntu-latest

--- a/image/workflow_commands.sh
+++ b/image/workflow_commands.sh
@@ -51,6 +51,14 @@ function debug_file() {
 }
 
 ##
+# Print a directory tree to the debug log
+#
+# This will be visible in the workflow log if ACTIONS_STEP_DEBUG workflow secret is set.
+function debug_tree () {
+    tree -ahuF --du "$@" | while IFS= read -r line; do echo "::debug::tree:${line}"; done
+}
+
+##
 # Set an output value
 #
 function set_output() {

--- a/tests/workflows/test-http/http-module/netrc
+++ b/tests/workflows/test-http/http-module/netrc
@@ -1,0 +1,3 @@
+machine example.com
+login dflook
+password 123456

--- a/tests/workflows/test-registry/terraformrc
+++ b/tests/workflows/test-registry/terraformrc
@@ -1,0 +1,3 @@
+credentials "terraform.example.com" {
+  token = "abcdefg"
+}


### PR DESCRIPTION
Some credentials are required to be on disk in the home directory. This directory is mounted by the runner, and some self-hosted runners don't clear them between jobs. Instead write them to a directory inside the container and symlink to them, to stop them possibly leaking into another job.

Cleans up some unhelpful logs and use tree instead of ls