### PR TITLE
Add GITHUB_DOM_COM_TOKEN

### DIFF
--- a/image/src/opentofu/github.py
+++ b/image/src/opentofu/github.py
@@ -2,9 +2,12 @@ from github_actions.api import GithubApi
 import os
 
 # This provides a github client for github.com
-# It will use a provided token, if we think it is for github.com and not an enterprise instance
 
-if os.environ.get('GITHUB_API_URL', 'https://api.github.com') == 'https://api.github.com':
+if os.environ.get('GITHUB_DOT_COM_TOKEN'):
+    # We have a specific token for github.com
+    token = os.environ.get('GITHUB_DOT_COM_TOKEN')
+elif os.environ.get('GITHUB_API_URL', 'https://api.github.com') == 'https://api.github.com':
+    # Use the provided GITHUB_TOKEN, if we think it is for github.com and not an enterprise instance
     token = os.environ.get('TERRAFORM_ACTIONS_GITHUB_TOKEN')
 else:
     token = None

--- a/terraform-apply/README.md
+++ b/terraform-apply/README.md
@@ -299,6 +299,15 @@ These input values must be the same as any [`dflook/terraform-plan`](https://git
   - Type: string
   - Optional
 
+* `GITHUB_DOT_COM_TOKEN`
+
+  This is used to specify a token for GitHub.com when the action is running on a GitHub Enterprise instance.
+  This is only used for downloading OpenTofu binaries from GitHub.com.
+  If this is not set, an unauthenticated request will be made to GitHub.com to download the binary, which may be rate limited.
+
+  - Type: string
+  - Optional
+
 * `TERRAFORM_CLOUD_TOKENS`
 
   API tokens for cloud hosts, of the form `<host>=<token>`. Multiple tokens may be specified, one per line.

--- a/terraform-check/README.md
+++ b/terraform-check/README.md
@@ -101,6 +101,15 @@ This is intended to run on a schedule to notify if manual changes to your infras
 
 ## Environment Variables
 
+* `GITHUB_DOT_COM_TOKEN`
+
+  This is used to specify a token for GitHub.com when the action is running on a GitHub Enterprise instance.
+  This is only used for downloading OpenTofu binaries from GitHub.com.
+  If this is not set, an unauthenticated request will be made to GitHub.com to download the binary, which may be rate limited.
+
+  - Type: string
+  - Optional
+
 * `TERRAFORM_CLOUD_TOKENS`
 
   API tokens for cloud hosts, of the form `<host>=<token>`. Multiple tokens may be specified, one per line.

--- a/terraform-destroy-workspace/README.md
+++ b/terraform-destroy-workspace/README.md
@@ -119,6 +119,15 @@ This action uses the `terraform destroy` command to destroy all resources in a T
 
 ## Environment Variables
 
+* `GITHUB_DOT_COM_TOKEN`
+
+  This is used to specify a token for GitHub.com when the action is running on a GitHub Enterprise instance.
+  This is only used for downloading OpenTofu binaries from GitHub.com.
+  If this is not set, an unauthenticated request will be made to GitHub.com to download the binary, which may be rate limited.
+
+  - Type: string
+  - Optional
+
 * `TERRAFORM_CLOUD_TOKENS`
 
   API tokens for cloud hosts, of the form `<host>=<token>`. Multiple tokens may be specified, one per line.

--- a/terraform-destroy/README.md
+++ b/terraform-destroy/README.md
@@ -123,6 +123,15 @@ and [dflook/terraform-apply](https://github.com/dflook/terraform-github-actions/
 
 ## Environment Variables
 
+* `GITHUB_DOT_COM_TOKEN`
+
+  This is used to specify a token for GitHub.com when the action is running on a GitHub Enterprise instance.
+  This is only used for downloading OpenTofu binaries from GitHub.com.
+  If this is not set, an unauthenticated request will be made to GitHub.com to download the binary, which may be rate limited.
+
+  - Type: string
+  - Optional
+
 * `TERRAFORM_CLOUD_TOKENS`
 
   API tokens for cloud hosts, of the form `<host>=<token>`. Multiple tokens may be specified, one per line.

--- a/terraform-fmt-check/README.md
+++ b/terraform-fmt-check/README.md
@@ -62,6 +62,15 @@ If any files are not correctly formatted a failing GitHub check will be added fo
 
 ## Environment Variables
 
+* `GITHUB_DOT_COM_TOKEN`
+
+  This is used to specify a token for GitHub.com when the action is running on a GitHub Enterprise instance.
+  This is only used for downloading OpenTofu binaries from GitHub.com.
+  If this is not set, an unauthenticated request will be made to GitHub.com to download the binary, which may be rate limited.
+
+  - Type: string
+  - Optional
+
 * `TERRAFORM_CLOUD_TOKENS`
 
   For the purpose of detecting the Terraform version to use from a cloud backend.

--- a/terraform-fmt/README.md
+++ b/terraform-fmt/README.md
@@ -51,6 +51,15 @@ This action uses the `terraform fmt -recursive` command to reformat files in a d
 
 ## Environment Variables
 
+* `GITHUB_DOT_COM_TOKEN`
+
+  This is used to specify a token for GitHub.com when the action is running on a GitHub Enterprise instance.
+  This is only used for downloading OpenTofu binaries from GitHub.com.
+  If this is not set, an unauthenticated request will be made to GitHub.com to download the binary, which may be rate limited.
+
+  - Type: string
+  - Optional
+
 * `TERRAFORM_CLOUD_TOKENS`
 
   For the purpose of detecting the Terraform version to use from a cloud backend.

--- a/terraform-new-workspace/README.md
+++ b/terraform-new-workspace/README.md
@@ -48,6 +48,15 @@ Creates a new Terraform workspace. If the workspace already exists, succeeds wit
 
 ## Environment Variables
 
+* `GITHUB_DOT_COM_TOKEN`
+
+  This is used to specify a token for GitHub.com when the action is running on a GitHub Enterprise instance.
+  This is only used for downloading OpenTofu binaries from GitHub.com.
+  If this is not set, an unauthenticated request will be made to GitHub.com to download the binary, which may be rate limited.
+
+  - Type: string
+  - Optional
+
 * `TERRAFORM_CLOUD_TOKENS`
 
   API tokens for cloud hosts, of the form `<host>=<token>`. Multiple tokens may be specified, one per line.

--- a/terraform-output/README.md
+++ b/terraform-output/README.md
@@ -49,6 +49,15 @@ Retrieve the root-level outputs from a Terraform configuration.
 
 ## Environment Variables
 
+* `GITHUB_DOT_COM_TOKEN`
+
+  This is used to specify a token for GitHub.com when the action is running on a GitHub Enterprise instance.
+  This is only used for downloading OpenTofu binaries from GitHub.com.
+  If this is not set, an unauthenticated request will be made to GitHub.com to download the binary, which may be rate limited.
+
+  - Type: string
+  - Optional
+
 * `TERRAFORM_CLOUD_TOKENS`
 
   API tokens for cloud hosts, of the form `<host>=<token>`. Multiple tokens may be specified, one per line.

--- a/terraform-plan/README.md
+++ b/terraform-plan/README.md
@@ -200,6 +200,15 @@ The [dflook/terraform-apply](https://github.com/dflook/terraform-github-actions/
   - Type: string
   - Optional
 
+* `GITHUB_DOT_COM_TOKEN`
+
+  This is used to specify a token for GitHub.com when the action is running on a GitHub Enterprise instance.
+  This is only used for downloading OpenTofu binaries from GitHub.com.
+  If this is not set, an unauthenticated request will be made to GitHub.com to download the binary, which may be rate limited.
+
+  - Type: string
+  - Optional
+
 * `TERRAFORM_CLOUD_TOKENS`
 
   API tokens for cloud hosts, of the form `<host>=<token>`. Multiple tokens may be specified, one per line.

--- a/terraform-remote-state/README.md
+++ b/terraform-remote-state/README.md
@@ -48,6 +48,15 @@ Retrieves the root-level outputs from a Terraform remote state.
 
 ## Environment Variables
 
+* `GITHUB_DOT_COM_TOKEN`
+
+  This is used to specify a token for GitHub.com when the action is running on a GitHub Enterprise instance.
+  This is only used for downloading OpenTofu binaries from GitHub.com.
+  If this is not set, an unauthenticated request will be made to GitHub.com to download the binary, which may be rate limited.
+
+  - Type: string
+  - Optional
+
 * `TERRAFORM_CLOUD_TOKENS`
 
   API tokens for cloud hosts, of the form `<host>=<token>`. Multiple tokens may be specified, one per line.

--- a/terraform-unlock-state/README.md
+++ b/terraform-unlock-state/README.md
@@ -56,6 +56,15 @@ Force unlocks a Terraform remote state.
 
 ## Environment Variables
 
+* `GITHUB_DOT_COM_TOKEN`
+
+  This is used to specify a token for GitHub.com when the action is running on a GitHub Enterprise instance.
+  This is only used for downloading OpenTofu binaries from GitHub.com.
+  If this is not set, an unauthenticated request will be made to GitHub.com to download the binary, which may be rate limited.
+
+  - Type: string
+  - Optional
+
 * `TERRAFORM_CLOUD_TOKENS`
 
   API tokens for cloud hosts, of the form `<host>=<token>`. Multiple tokens may be specified, one per line.

--- a/terraform-validate/README.md
+++ b/terraform-validate/README.md
@@ -71,6 +71,15 @@ If the Terraform configuration is not valid, the build is failed.
 
 ## Environment Variables
 
+* `GITHUB_DOT_COM_TOKEN`
+
+  This is used to specify a token for GitHub.com when the action is running on a GitHub Enterprise instance.
+  This is only used for downloading OpenTofu binaries from GitHub.com.
+  If this is not set, an unauthenticated request will be made to GitHub.com to download the binary, which may be rate limited.
+
+  - Type: string
+  - Optional
+
 * `TERRAFORM_CLOUD_TOKENS`
 
   API tokens for cloud hosts, of the form `<host>=<token>`. Multiple tokens may be specified, one per line.

--- a/terraform-version/README.md
+++ b/terraform-version/README.md
@@ -75,6 +75,15 @@ outputs yourself.
 
 ## Environment Variables
 
+* `GITHUB_DOT_COM_TOKEN`
+
+  This is used to specify a token for GitHub.com when the action is running on a GitHub Enterprise instance.
+  This is only used for downloading OpenTofu binaries from GitHub.com.
+  If this is not set, an unauthenticated request will be made to GitHub.com to download the binary, which may be rate limited.
+
+  - Type: string
+  - Optional
+
 * `TERRAFORM_CLOUD_TOKENS`
 
   API tokens for cloud hosts, of the form `<host>=<token>`. Multiple tokens may be specified, one per line.

--- a/tofu-apply/README.md
+++ b/tofu-apply/README.md
@@ -299,6 +299,15 @@ These input values must be the same as any [`dflook/tofu-plan`](https://github.c
   - Type: string
   - Optional
 
+* `GITHUB_DOT_COM_TOKEN`
+
+  This is used to specify a token for GitHub.com when the action is running on a GitHub Enterprise instance.
+  This is only used for downloading OpenTofu binaries from GitHub.com.
+  If this is not set, an unauthenticated request will be made to GitHub.com to download the binary, which may be rate limited.
+
+  - Type: string
+  - Optional
+
 * `TERRAFORM_CLOUD_TOKENS`
 
   API tokens for cloud hosts, of the form `<host>=<token>`. Multiple tokens may be specified, one per line.

--- a/tofu-check/README.md
+++ b/tofu-check/README.md
@@ -101,6 +101,15 @@ This is intended to run on a schedule to notify if manual changes to your infras
 
 ## Environment Variables
 
+* `GITHUB_DOT_COM_TOKEN`
+
+  This is used to specify a token for GitHub.com when the action is running on a GitHub Enterprise instance.
+  This is only used for downloading OpenTofu binaries from GitHub.com.
+  If this is not set, an unauthenticated request will be made to GitHub.com to download the binary, which may be rate limited.
+
+  - Type: string
+  - Optional
+
 * `TERRAFORM_CLOUD_TOKENS`
 
   API tokens for cloud hosts, of the form `<host>=<token>`. Multiple tokens may be specified, one per line.

--- a/tofu-destroy-workspace/README.md
+++ b/tofu-destroy-workspace/README.md
@@ -119,6 +119,15 @@ This action uses the `tofu destroy` command to destroy all resources in an OpenT
 
 ## Environment Variables
 
+* `GITHUB_DOT_COM_TOKEN`
+
+  This is used to specify a token for GitHub.com when the action is running on a GitHub Enterprise instance.
+  This is only used for downloading OpenTofu binaries from GitHub.com.
+  If this is not set, an unauthenticated request will be made to GitHub.com to download the binary, which may be rate limited.
+
+  - Type: string
+  - Optional
+
 * `TERRAFORM_CLOUD_TOKENS`
 
   API tokens for cloud hosts, of the form `<host>=<token>`. Multiple tokens may be specified, one per line.

--- a/tofu-destroy/README.md
+++ b/tofu-destroy/README.md
@@ -123,6 +123,15 @@ and [dflook/tofu-apply](https://github.com/dflook/terraform-github-actions/tree/
 
 ## Environment Variables
 
+* `GITHUB_DOT_COM_TOKEN`
+
+  This is used to specify a token for GitHub.com when the action is running on a GitHub Enterprise instance.
+  This is only used for downloading OpenTofu binaries from GitHub.com.
+  If this is not set, an unauthenticated request will be made to GitHub.com to download the binary, which may be rate limited.
+
+  - Type: string
+  - Optional
+
 * `TERRAFORM_CLOUD_TOKENS`
 
   API tokens for cloud hosts, of the form `<host>=<token>`. Multiple tokens may be specified, one per line.

--- a/tofu-fmt-check/README.md
+++ b/tofu-fmt-check/README.md
@@ -62,6 +62,15 @@ If any files are not correctly formatted a failing GitHub check will be added fo
 
 ## Environment Variables
 
+* `GITHUB_DOT_COM_TOKEN`
+
+  This is used to specify a token for GitHub.com when the action is running on a GitHub Enterprise instance.
+  This is only used for downloading OpenTofu binaries from GitHub.com.
+  If this is not set, an unauthenticated request will be made to GitHub.com to download the binary, which may be rate limited.
+
+  - Type: string
+  - Optional
+
 * `TERRAFORM_CLOUD_TOKENS`
 
   For the purpose of detecting the OpenTofu version to use from a cloud backend.

--- a/tofu-fmt/README.md
+++ b/tofu-fmt/README.md
@@ -51,6 +51,15 @@ This action uses the `tofu fmt -recursive` command to reformat files in a direct
 
 ## Environment Variables
 
+* `GITHUB_DOT_COM_TOKEN`
+
+  This is used to specify a token for GitHub.com when the action is running on a GitHub Enterprise instance.
+  This is only used for downloading OpenTofu binaries from GitHub.com.
+  If this is not set, an unauthenticated request will be made to GitHub.com to download the binary, which may be rate limited.
+
+  - Type: string
+  - Optional
+
 * `TERRAFORM_CLOUD_TOKENS`
 
   For the purpose of detecting the OpenTofu version to use from a cloud backend.

--- a/tofu-new-workspace/README.md
+++ b/tofu-new-workspace/README.md
@@ -48,6 +48,15 @@ Creates a new OpenTofu workspace. If the workspace already exists, succeeds with
 
 ## Environment Variables
 
+* `GITHUB_DOT_COM_TOKEN`
+
+  This is used to specify a token for GitHub.com when the action is running on a GitHub Enterprise instance.
+  This is only used for downloading OpenTofu binaries from GitHub.com.
+  If this is not set, an unauthenticated request will be made to GitHub.com to download the binary, which may be rate limited.
+
+  - Type: string
+  - Optional
+
 * `TERRAFORM_CLOUD_TOKENS`
 
   API tokens for cloud hosts, of the form `<host>=<token>`. Multiple tokens may be specified, one per line.

--- a/tofu-output/README.md
+++ b/tofu-output/README.md
@@ -49,6 +49,15 @@ Retrieve the root-level outputs from an OpenTofu configuration.
 
 ## Environment Variables
 
+* `GITHUB_DOT_COM_TOKEN`
+
+  This is used to specify a token for GitHub.com when the action is running on a GitHub Enterprise instance.
+  This is only used for downloading OpenTofu binaries from GitHub.com.
+  If this is not set, an unauthenticated request will be made to GitHub.com to download the binary, which may be rate limited.
+
+  - Type: string
+  - Optional
+
 * `TERRAFORM_CLOUD_TOKENS`
 
   API tokens for cloud hosts, of the form `<host>=<token>`. Multiple tokens may be specified, one per line.

--- a/tofu-plan/README.md
+++ b/tofu-plan/README.md
@@ -200,6 +200,15 @@ The [dflook/tofu-apply](https://github.com/dflook/terraform-github-actions/tree/
   - Type: string
   - Optional
 
+* `GITHUB_DOT_COM_TOKEN`
+
+  This is used to specify a token for GitHub.com when the action is running on a GitHub Enterprise instance.
+  This is only used for downloading OpenTofu binaries from GitHub.com.
+  If this is not set, an unauthenticated request will be made to GitHub.com to download the binary, which may be rate limited.
+
+  - Type: string
+  - Optional
+
 * `TERRAFORM_CLOUD_TOKENS`
 
   API tokens for cloud hosts, of the form `<host>=<token>`. Multiple tokens may be specified, one per line.

--- a/tofu-remote-state/README.md
+++ b/tofu-remote-state/README.md
@@ -48,6 +48,15 @@ Retrieves the root-level outputs from an OpenTofu remote state.
 
 ## Environment Variables
 
+* `GITHUB_DOT_COM_TOKEN`
+
+  This is used to specify a token for GitHub.com when the action is running on a GitHub Enterprise instance.
+  This is only used for downloading OpenTofu binaries from GitHub.com.
+  If this is not set, an unauthenticated request will be made to GitHub.com to download the binary, which may be rate limited.
+
+  - Type: string
+  - Optional
+
 * `TERRAFORM_CLOUD_TOKENS`
 
   API tokens for cloud hosts, of the form `<host>=<token>`. Multiple tokens may be specified, one per line.

--- a/tofu-unlock-state/README.md
+++ b/tofu-unlock-state/README.md
@@ -56,6 +56,15 @@ Force unlocks an OpenTofu remote state.
 
 ## Environment Variables
 
+* `GITHUB_DOT_COM_TOKEN`
+
+  This is used to specify a token for GitHub.com when the action is running on a GitHub Enterprise instance.
+  This is only used for downloading OpenTofu binaries from GitHub.com.
+  If this is not set, an unauthenticated request will be made to GitHub.com to download the binary, which may be rate limited.
+
+  - Type: string
+  - Optional
+
 * `TERRAFORM_CLOUD_TOKENS`
 
   API tokens for cloud hosts, of the form `<host>=<token>`. Multiple tokens may be specified, one per line.

--- a/tofu-validate/README.md
+++ b/tofu-validate/README.md
@@ -71,6 +71,15 @@ If the OpenTofu configuration is not valid, the build is failed.
 
 ## Environment Variables
 
+* `GITHUB_DOT_COM_TOKEN`
+
+  This is used to specify a token for GitHub.com when the action is running on a GitHub Enterprise instance.
+  This is only used for downloading OpenTofu binaries from GitHub.com.
+  If this is not set, an unauthenticated request will be made to GitHub.com to download the binary, which may be rate limited.
+
+  - Type: string
+  - Optional
+
 * `TERRAFORM_CLOUD_TOKENS`
 
   API tokens for cloud hosts, of the form `<host>=<token>`. Multiple tokens may be specified, one per line.

--- a/tofu-version/README.md
+++ b/tofu-version/README.md
@@ -75,6 +75,15 @@ outputs yourself.
 
 ## Environment Variables
 
+* `GITHUB_DOT_COM_TOKEN`
+
+  This is used to specify a token for GitHub.com when the action is running on a GitHub Enterprise instance.
+  This is only used for downloading OpenTofu binaries from GitHub.com.
+  If this is not set, an unauthenticated request will be made to GitHub.com to download the binary, which may be rate limited.
+
+  - Type: string
+  - Optional
+
 * `TERRAFORM_CLOUD_TOKENS`
 
   API tokens for cloud hosts, of the form `<host>=<token>`. Multiple tokens may be specified, one per line.


### PR DESCRIPTION
This allows specifying a token for github.com, when running on a github enterprise instance.
When specified, it will be used for downloading OpenTofu, avoiding the severe rate limiting of unauthenticated requests.