### PR TITLE
[FIX #337] support terraform plan -refresh=false

### DIFF
--- a/image/actions.sh
+++ b/image/actions.sh
@@ -357,6 +357,12 @@ function set-common-plan-args() {
             PLAN_ARGS="$PLAN_ARGS -destroy"
         fi
     fi
+
+    if [[ -v INPUT_REFRESH ]]; then
+        if [[ "$INPUT_REFRESH" == "false" ]]; then
+          PLAN_ARGS="$PLAN_ARGS -refresh=false"
+        fi
+    fi
 }
 
 function set-variable-args() {

--- a/terraform-plan/action.yaml
+++ b/terraform-plan/action.yaml
@@ -82,6 +82,10 @@ inputs:
     description: Limit the number of concurrent operations
     required: false
     default: "0"
+  refresh:
+    description: Skip checking for external changes to remote objects while creating the plan
+    required: false
+    default: "true"
 
 outputs:
   changes:

--- a/tofu-plan/action.yaml
+++ b/tofu-plan/action.yaml
@@ -82,6 +82,10 @@ inputs:
     description: Limit the number of concurrent operations
     required: false
     default: "0"
+  refresh:
+    description: Skip checking for external changes to remote objects while creating the plan
+    required: false
+    default: "true"
 
 outputs:
   changes:


### PR DESCRIPTION
https://github.com/dflook/terraform-github-actions/issues/337

Add the ability to support the `refresh-false` terraform plan argument.

```
-refresh=false      Skip checking for external changes to remote objects
                      while creating the plan. This can potentially make
                      planning faster, but at the expense of possibly planning
                      against a stale record of the remote system state.
```

https://developer.hashicorp.com/terraform/cli/commands/plan#planning-options
https://opentofu.org/docs/cli/commands/plan/#planning-options
