### PR TITLE
Add support for ephemeral variables in terraform >= 1.10.0

### DIFF
--- a/.github/workflows/test-apply.yaml
+++ b/.github/workflows/test-apply.yaml
@@ -1430,3 +1430,100 @@ jobs:
         uses: ./terraform-apply
         with:
           path: tests/workflows/test-apply/outputs
+
+  ephemeral:
+    runs-on: ubuntu-24.04
+    name: Apply a plan with ephemeral variables
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Plan using default ephemeral value
+        uses: ./terraform-plan
+        with:
+          label: test-apply ephemeral
+          path: tests/workflows/test-apply/ephemeral
+
+      - name: Apply using default ephemeral value
+        uses: ./terraform-apply
+        id: apply
+        with:
+          label: test-apply ephemeral
+          path: tests/workflows/test-apply/ephemeral
+
+      - name: Verify outputs
+        env:
+          OUTPUT_STRING: ${{ steps.apply.outputs.v }}
+        run: |
+          if [[ "$OUTPUT_STRING" != "non-ephemeral" ]]; then
+            echo "::error:: output s not set correctly"
+            exit 1
+          fi
+
+      ##
+
+      - name: Plan using explicit ephemeral value
+        uses: ./terraform-plan
+        with:
+          label: test-apply ephemeral 2
+          path: tests/workflows/test-apply/ephemeral
+          variables: |
+            region = "eu-west-1"
+            mv = "hello"
+
+      - name: Apply using explicit ephemeral value
+        uses: ./terraform-apply
+        id: apply2
+        with:
+          label: test-apply ephemeral 2
+          path: tests/workflows/test-apply/ephemeral
+          variables: |
+            region = "eu-west-1"
+            mv = "hello"
+
+      - name: Verify outputs
+        env:
+          OUTPUT_STRING: ${{ steps.apply2.outputs.v }}
+        run: |
+          if [[ "$OUTPUT_STRING" != "hello" ]]; then
+            echo "::error:: output s not set correctly"
+            exit 1
+          fi
+
+      ##
+
+      - name: Plan using explicit non-ephemeral value
+        uses: ./terraform-plan
+        with:
+          label: test-apply ephemeral 3
+          path: tests/workflows/test-apply/ephemeral
+          variables: |
+            region = "eu-west-2"
+            mv = "goodbye"
+
+      - name: Apply using mismatched explicit non-ephemeral value
+        uses: ./terraform-apply
+        continue-on-error: true
+        id: apply3
+        with:
+          label: test-apply ephemeral 3
+          path: tests/workflows/test-apply/ephemeral
+          variables: |
+            region = "eu-west-2"
+            mv = "mismatch"
+
+      - name: Check failed to apply
+        env:
+          OUTCOME: ${{ steps.apply3.outcome }}
+        run: |
+          if [[ "$OUTCOME" != "failure" ]]; then
+            echo "Apply did not fail correctly"
+            exit 1
+          fi

--- a/image/entrypoints/test.sh
+++ b/image/entrypoints/test.sh
@@ -30,11 +30,11 @@ function set-test-args() {
 
 function test() {
 
-    debug_log $TOOL_COMMAND_NAME test -no-color $TEST_ARGS '$PLAN_ARGS'  # don't expand PLAN_ARGS
+    debug_log $TOOL_COMMAND_NAME test -no-color $TEST_ARGS $VARIABLE_ARGS
 
     set +e
     # shellcheck disable=SC2086
-    (cd "$INPUT_PATH" && $TOOL_COMMAND_NAME test -no-color $TEST_ARGS $PLAN_ARGS) \
+    (cd "$INPUT_PATH" && $TOOL_COMMAND_NAME test -no-color $TEST_ARGS $VARIABLE_ARGS) \
         2>"$STEP_TMP_DIR/terraform_test.stderr" \
         | tee /dev/fd/3 \
             >"$STEP_TMP_DIR/terraform_test.stdout"
@@ -59,7 +59,6 @@ function test() {
 }
 
 set-test-args
-PLAN_ARGS=""
 set-variable-args
 
 test

--- a/image/src/github_pr_comment/__main__.py
+++ b/image/src/github_pr_comment/__main__.py
@@ -642,8 +642,6 @@ def main() -> int:
 
             debug(f'diff {proposed_plan_path} {approved_plan_path}')
             diff_complete = subprocess.run(['diff', proposed_plan_path, approved_plan_path], check=False, capture_output=True, encoding='utf-8')
-            sys.stdout.write(diff_complete.stdout)
-            sys.stderr.write(diff_complete.stderr)
 
             if diff_complete.returncode != 0:
                 sys.stdout.write("""Performing diff between the pull request plan and the plan generated at execution time.
@@ -651,6 +649,9 @@ def main() -> int:
 < are lines from the plan generated at execution
 Plan differences:
 """)
+
+            sys.stdout.write(diff_complete.stdout)
+            sys.stderr.write(diff_complete.stderr)
 
             if comment.headers.get('plan_text_format', 'text').endswith('trunc'):
                 sys.stdout.write('\nThe plan text was too large for a PR comment, not all differences may be shown here.')

--- a/tests/workflows/test-apply/ephemeral/main.tf
+++ b/tests/workflows/test-apply/ephemeral/main.tf
@@ -1,0 +1,25 @@
+variable "region" {
+  type = string
+  default = "eu-west-2"
+}
+
+variable "mv" {
+  type = string
+  default = "non-ephemeral"
+}
+
+provider "aws" {
+  region = var.region
+}
+
+output "v" {
+  value = var.mv
+}
+
+resource "random_string" "add" {
+  length = 5
+}
+
+terraform {
+  required_version = ">=1.10"
+}


### PR DESCRIPTION
These must be specified again when applying a saved plan, but must not be specified in earlier versions of Terraform or OpenTofu