### PR TITLE
Add a junit-xml-path output for the test action

### DIFF
--- a/.github/workflows/test-test.yaml
+++ b/.github/workflows/test-test.yaml
@@ -19,16 +19,67 @@ jobs:
       - name: Test
         uses: ./terraform-test
         id: test
+        env:
+          TERRAFORM_VERSION: 1.10.0
         with:
           path: tests/workflows/test-test/local
 
       - name: Check Passed
         env:
           FAILURE_REASON: ${{ steps.test.outputs.failure-reason }}
+          JUNIT_XML_PATH: ${{ steps.test.outputs.junit-xml-path }}
         run: |
           if [[ "$FAILURE_REASON" != "" ]]; then
             echo "::error:: failure-reason not set correctly"
             exit 1
+          fi
+          
+          if [[ "$JUNIT_XML_PATH" != "" ]]; then
+            echo "::error:: junit-xml-path should not be set"
+            exit 1
+          fi
+
+  junit:
+    runs-on: ubuntu-24.04
+    name: Junit support
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Test
+        uses: ./terraform-test
+        id: test
+        env:
+          TERRAFORM_VERSION: 1.11.0
+        with:
+          path: tests/workflows/test-test/local
+
+      - name: Check Passed
+        env:
+          FAILURE_REASON: ${{ steps.test.outputs.failure-reason }}
+          JUNIT_XML_PATH: ${{ steps.test.outputs.junit-xml-path }}
+        run: |
+          if [[ "$FAILURE_REASON" != "" ]]; then
+            echo "::error:: failure-reason not set correctly"
+            exit 1
+          fi
+          
+          if [[ "$JUNIT_XML_PATH" == "" ]]; then
+            echo "::error:: junit-xml-path should be set"
+            exit 1
+          fi
+
+          # Check the output looks right
+          if [[ ! -f "$JUNIT_XML_PATH" ]]; then
+              echo "::error:: junit-xml-path does not point to a file"
+              exit 1
+          fi
+          
+          if [[ "$(grep -c '<testsuites' "$JUNIT_XML_PATH")" -ne 1 ]]; then
+              echo "::error:: junit-xml-path does not contain a testsuites tag"
+              exit 1
           fi
 
   filter:

--- a/.github/workflows/test-version.yaml
+++ b/.github/workflows/test-version.yaml
@@ -611,7 +611,7 @@ jobs:
         run: |
           echo "The terraform version was $DETECTED_TERRAFORM_VERSION"
 
-          if [[ "$DETECTED_TERRAFORM_VERSION" != *"1.10"* ]]; then
+          if [[ "$DETECTED_TERRAFORM_VERSION" != *"1.11"* ]]; then
             echo "::error:: Latest version was not used"
             exit 1
           fi

--- a/docs-gen/actions/test.py
+++ b/docs-gen/actions/test.py
@@ -12,6 +12,7 @@ from inputs.test_filter import test_filter
 from inputs.var_file import var_file
 from inputs.variables import variables
 from outputs.failure_reason import failure_reason
+from outputs.junit_xml import junit_xml_path
 
 test = Action(
     'test',
@@ -31,6 +32,7 @@ test = Action(
         var_file
     ],
     outputs=[
+        junit_xml_path,
         dataclasses.replace(failure_reason, description='''
           When the job outcome is `failure`, this output may be set. The value may be one of:
         

--- a/docs-gen/outputs/junit_xml.py
+++ b/docs-gen/outputs/junit_xml.py
@@ -1,0 +1,14 @@
+from action import Output, Terraform
+
+junit_xml_path = Output(
+    name='junit-xml-path',
+    type='string',
+    description='''
+A test report in JUnit XML format.
+
+The path is relative to the Actions workspace.
+
+This will only be available when using Terraform 1.11.0 or later.
+''',
+    available_in = [Terraform]
+)

--- a/image/entrypoints/test.sh
+++ b/image/entrypoints/test.sh
@@ -26,6 +26,10 @@ function set-test-args() {
             TEST_ARGS="$TEST_ARGS -filter=$file"
         done
     fi
+
+    if [[ "$TOOL_COMMAND_NAME" == "terraform" && $TERRAFORM_VER_MAJOR -ge 1 && $TERRAFORM_VER_MINOR -ge 11 ]]; then
+        TEST_ARGS="$TEST_ARGS -junit-xml=$STEP_TMP_DIR/test-result.xml"
+    fi
 }
 
 function test() {
@@ -44,6 +48,12 @@ function test() {
     set -e
 
     cat "$STEP_TMP_DIR/terraform_test.stderr"
+
+    if [[ -f "$STEP_TMP_DIR/test-result.xml" ]]; then
+      mkdir -p "$GITHUB_WORKSPACE/$WORKSPACE_TMP_DIR"
+      cp "$STEP_TMP_DIR/test-result.xml" "$GITHUB_WORKSPACE/$WORKSPACE_TMP_DIR/test-result.xml"
+      set_output junit-xml-path "$WORKSPACE_TMP_DIR/test-result.xml"
+    fi
 
     if [[ $TEST_EXIT -eq 0 ]]; then
         # Workaround a bit of stupidity in the terraform test command

--- a/terraform-test/README.md
+++ b/terraform-test/README.md
@@ -81,6 +81,16 @@ If the tests fail, the job will stop with a failure status.
 
 ## Outputs
 
+* `junit-xml-path`
+
+  A test report in JUnit XML format.
+
+  The path is relative to the Actions workspace.
+
+  This will only be available when using Terraform 1.11.0 or later.
+
+  - Type: string
+
 * `failure-reason`
 
   When the job outcome is `failure`, this output may be set. The value may be one of:

--- a/terraform-test/action.yaml
+++ b/terraform-test/action.yaml
@@ -31,6 +31,13 @@ inputs:
     required: false
 
 outputs:
+  junit-xml-path:
+    description: |
+      A test report in JUnit XML format.
+
+      The path is relative to the Actions workspace.
+
+      This will only be available when using Terraform 1.11.0 or later.
   failure-reason:
     description: |
       When the job outcome is `failure`, this output may be set. The value may be one of:


### PR DESCRIPTION
Adds a `junit-xml-path` output for the test action, which is set to the path of the junit test report when using Terraform >=1.11.0