### PR TITLE
Fix incorrect plan changed report with truncated plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,15 @@ The actions are versioned as a suite. Some actions may have no change in behavio
 
 When using an action you can specify the version as:
 
-- `@v2.2.0` to use an exact release
+- `@v2.2.1` to use an exact release
 - `@v2.2` to use the latest patch release for the specific minor version
 - `@v2` to use the latest patch release for the specific major version
+
+## [2.2.1] - 2025-08-02
+
+### Fixed
+- Fixed incorrect plan difference reporting when an apply is aborted because the plan changed, with plans that are too large for PR comments.
+  Previously, when a plan was truncated due to size limits, the diff output would show misleading whitespace-only differences, causing confusion about what had actually changed.
 
 ## [2.2.0] - 2025-08-01
 
@@ -785,6 +791,7 @@ First release of the GitHub Actions:
 - [dflook/terraform-new-workspace](terraform-new-workspace)
 - [dflook/terraform-destroy-workspace](terraform-destroy-workspace)
 
+[2.2.1]: https://github.com/dflook/terraform-github-actions/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/dflook/terraform-github-actions/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/dflook/terraform-github-actions/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/dflook/terraform-github-actions/compare/v2.0.0...v2.0.1

--- a/image/src/github_pr_comment/__main__.py
+++ b/image/src/github_pr_comment/__main__.py
@@ -639,7 +639,7 @@ def main() -> int:
 
             proposed_plan_path = os.path.join(os.environ['STEP_TMP_DIR'], 'proposed-plan.txt')
             with open(proposed_plan_path, 'w') as f:
-                format_type = 'diff' if comment.headers.get('plan_text_format', 'text') == 'diff' else 'text'
+                format_type = 'diff' if comment.headers.get('plan_text_format', 'text').startswith('diff') else 'text'
                 _, formatted_proposed_plan = format_plan_text(proposed_plan.strip(), format_type)
                 f.write(formatted_proposed_plan.strip())
 


### PR DESCRIPTION
When a plan had changed between the plan and apply actions, we print an informative diff of the changes to the workflow log. This diff was not being created correctly if the plan was too long to fit in a PR comment and had been truncated.

This resulting in noisy and confusing 'changed' plans that were mostly whitespace.