### PR TITLE
Better detect plan summary line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,15 @@ The actions are versioned as a suite. Some actions may have no change in behavio
 
 When using an action you can specify the version as:
 
-- `@v2.2.1` to use an exact release
+- `@v2.2.2` to use an exact release
 - `@v2.2` to use the latest patch release for the specific minor version
 - `@v2` to use the latest patch release for the specific major version
+
+## [2.2.2] - 2025-08-08
+
+### Fixed
+- [dflook/terraform-apply](https://github.com/dflook/terraform-github-actions/tree/main/terraform-apply)/[dflook/tofu-apply](https://github.com/dflook/terraform-github-actions/tree/main/tofu-apply)
+  could mistakenly think the plan had changed and abort the apply operation, if the plan imported resources and also contained warnings.
 
 ## [2.2.1] - 2025-08-02
 
@@ -791,6 +797,7 @@ First release of the GitHub Actions:
 - [dflook/terraform-new-workspace](terraform-new-workspace)
 - [dflook/terraform-destroy-workspace](terraform-destroy-workspace)
 
+[2.2.2]: https://github.com/dflook/terraform-github-actions/compare/v2.2.1...v2.2.2
 [2.2.1]: https://github.com/dflook/terraform-github-actions/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/dflook/terraform-github-actions/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/dflook/terraform-github-actions/compare/v2.0.1...v2.1.0

--- a/image/src/github_pr_comment/cmp.py
+++ b/image/src/github_pr_comment/cmp.py
@@ -23,7 +23,7 @@ def remove_warnings(plan: str) -> str:
 
         plan_lines.append(line)
 
-        if re.match(r'Plan: \d+ to add, \d+ to change, \d+ to destroy', line):
+        if re.match(r'Plan: \d+ to \S+', line):
             plan_summary_reached = True
 
     return '\n'.join(plan_lines).strip()

--- a/tests/github_pr_comment/test_cmp.py
+++ b/tests/github_pr_comment/test_cmp.py
@@ -21,6 +21,80 @@ def test_remove_unchanged_attributes():
 
     assert remove_unchanged_attributes(plan) == expected
 
+
+def test_remove_warnings_with_import():
+    plan = '''
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # random_string.count[0] will be created
+  + resource "random_string" "count" {
+      + id          = (known after apply)
+      + length      = 5
+      + lower       = true
+      + min_lower   = 0
+      + min_numeric = 0
+      + min_special = 0
+      + min_upper   = 0
+      + number      = true
+      + numeric     = true
+      + result      = (known after apply)
+      + special     = false
+      + upper       = true
+    }
+
+Plan: 26 to import, 1 to add, 0 to change, 0 to destroy.
+
+Changes to Outputs:
+  + count = (known after apply)
+
+Warning: Resource targeting is in effect
+
+You are creating a plan with the -target option, which means that the result
+of this plan may not represent all of the changes requested by the current
+configuration.
+
+The -target option is not for routine use, and is provided only for
+exceptional situations such as recovering from errors or mistakes, or when
+Terraform specifically suggests to use it as part of an error message.  
+    '''
+
+    expected = '''
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # random_string.count[0] will be created
+  + resource "random_string" "count" {
+      + id          = (known after apply)
+      + length      = 5
+      + lower       = true
+      + min_lower   = 0
+      + min_numeric = 0
+      + min_special = 0
+      + min_upper   = 0
+      + number      = true
+      + numeric     = true
+      + result      = (known after apply)
+      + special     = false
+      + upper       = true
+    }
+
+Plan: 26 to import, 1 to add, 0 to change, 0 to destroy.
+
+Changes to Outputs:
+  + count = (known after apply)
+
+    '''
+
+    assert remove_warnings(plan).strip() == expected.strip()
+
+
 def test_remove_warnings():
     plan = '''
 Terraform used the selected providers to generate the following execution


### PR DESCRIPTION
This is so we can ignore any warning text that follows.
If a plan contains import operations, the line is different.