### PR TITLE
Updates the AUTO_TFVARS_COUNTER to increment in decimal

### DIFF
--- a/image/actions.sh
+++ b/image/actions.sh
@@ -423,7 +423,7 @@ function create-auto-tfvars() {
 
             debug_log "Creating autoloading tfvars file for $file_path: $link_name"
             cp "$file_path" "$INPUT_PATH/$link_name"
-            AUTO_TFVARS_COUNTER=$(printf "%02d\n" "$((AUTO_TFVARS_COUNTER + 1))")
+            AUTO_TFVARS_COUNTER=$(printf "%02d\n" "$((10#${AUTO_TFVARS_COUNTER} + 1))")
         done
     fi
 


### PR DESCRIPTION
As part of issue #415 when you have more than 8 vars files the action fails due to it evaluating numbers as octal. This can be reproduced in simple bash shell.

```bash
AUTO_TFVARS_COUNTER="00"

for i in {1..10}
> do
> AUTO_TFVARS_COUNTER=$(printf "%02d\n" "$((AUTO_TFVARS_COUNTER + 1))")
> echo $AUTO_TFVARS_COUNTER
> done
01
02
03
04
05
06
07
08
-bash: 08: value too great for base (error token is "08")
```

This fix will foce the number to decimal before incrementing it and will support any number of vars files. This again can be tested in bash

```bash
AUTO_TFVARS_COUNTER="00"

for i in {1..10}
> do
> AUTO_TFVARS_COUNTER=$(printf "%02d\n" "$((10#${AUTO_TFVARS_COUNTER} + 1))")
> echo $AUTO_TFVARS_COUNTER
> done
01
02
03
04
05
06
07
08
09
10
```