### PR TITLE
Use JSON plan output for deterministic plan hashing

### DIFF
--- a/image/src/github_pr_comment/__main__.py
+++ b/image/src/github_pr_comment/__main__.py
@@ -20,7 +20,7 @@ from github_pr_comment.backend_config import complete_config, partial_config
 from github_pr_comment.backend_fingerprint import fingerprint
 from github_pr_comment.cmp import plan_cmp, remove_warnings, remove_unchanged_attributes
 from github_pr_comment.comment import find_comment, TerraformComment, update_comment, serialize, deserialize, hide_comment
-from github_pr_comment.hash import comment_hash, plan_hash, plan_out_hash
+from github_pr_comment.hash import comment_hash, plan_hash, plan_json_hash, plan_out_hash
 from github_pr_comment.plan_formatting import format_diff
 from plan_renderer.outputs import render_outputs
 from plan_renderer.variables import render_argument_list, Sensitive
@@ -377,14 +377,28 @@ def get_comment(action_inputs: PlanPrInputs, backend_fingerprint: bytes, backup_
 
     return find_comment(github, issue_url, username, headers, backup_headers, legacy_description)
 
+def _json_plan_path() -> Optional[Path]:
+    workspace = os.environ.get('GITHUB_WORKSPACE')
+    workspace_tmp = os.environ.get('WORKSPACE_TMP_DIR')
+    if workspace and workspace_tmp:
+        p = Path(workspace) / workspace_tmp / 'plan.json'
+        return p if p.exists() else None
+    return None
+
 def is_approved(proposed_plan: str, comment: TerraformComment) -> bool:
 
+    if approved_json_hash := comment.headers.get('plan_json_hash'):
+        debug('Approving plan based on JSON plan hash')
+        if (json_path := _json_plan_path()) is not None:
+            return plan_json_hash(json_path, comment.issue_url) == approved_json_hash
+        debug('JSON plan not available, falling back to text hash')
+
     if approved_plan_hash := comment.headers.get('plan_hash'):
-        debug('Approving plan based on plan hash')
+        debug('Approving plan based on text plan hash')
         return plan_hash(proposed_plan, comment.issue_url) == approved_plan_hash
-    else:
-        debug('Approving plan based on plan text')
-        return plan_cmp(proposed_plan, comment.body)
+
+    debug('Approving plan based on plan text')
+    return plan_cmp(proposed_plan, comment.body)
 
 def is_approved_binary_plan(plan_path: str, comment: TerraformComment) -> bool:
     return plan_out_hash(plan_path, comment.issue_url) == comment.headers['plan_out_hash']
@@ -522,6 +536,8 @@ def main() -> int:
         elif 'plan_out_hash' in headers:
             del headers['plan_out_hash']
 
+        if (json_path := _json_plan_path()) is not None:
+            headers['plan_json_hash'] = plan_json_hash(json_path, comment.issue_url)
         headers['plan_hash'] = plan_hash(body, comment.issue_url)
         format_type = os.environ.get('TF_ACTIONS_PLAN_FORMAT', 'diff')
         headers['plan_text_format'], plan_text = format_plan_text(body, format_type)

--- a/image/src/github_pr_comment/comment.py
+++ b/image/src/github_pr_comment/comment.py
@@ -35,7 +35,8 @@ class TerraformComment:
         'backend_type',   # The backend type name
         'plan_modifier',  # Hash of plan modifiers (target/replace options)
         'plan_job_ref',   # A text reference to the actions job that generated the plan
-        'plan_hash',      # A deterministic hash of the plan (without warnings or unchanged attributes, eventually with unmasked variables)
+        'plan_hash',      # A deterministic hash of the plan text (legacy, retained for backward compatibility)
+        'plan_json_hash', # A deterministic hash of the JSON plan output (preferred over plan_hash)
         'variables_hash', # A hash of input variables and values
         'truncated'       # If the plan text has been truncated (should not be used to approve plans, and will not show a complete diff)
         'closed'          # If the comment has been closed for modifications

--- a/image/src/github_pr_comment/hash.py
+++ b/image/src/github_pr_comment/hash.py
@@ -1,4 +1,8 @@
 import hashlib
+import json
+from pathlib import Path
+
+import canonicaljson
 
 from github_actions.debug import debug
 from github_pr_comment.cmp import remove_warnings, remove_unchanged_attributes
@@ -10,15 +14,33 @@ def comment_hash(value: bytes, salt: str) -> str:
     return h.hexdigest()
 
 
+def plan_json_hash(json_plan_path: Path, salt: str) -> str:
+    """
+    Compute a deterministic hash of the plan using the JSON plan output.
+
+    Excluded volatile fields:
+    - timestamp: generated fresh on every plan run, carries no information about what will change
+    """
+
+    debug(f'Hashing JSON plan {json_plan_path} with salt {salt}')
+
+    with open(json_plan_path) as f:
+        plan = json.load(f)
+
+    plan.pop('timestamp', None)
+
+    return comment_hash(canonicaljson.encode_canonical_json(plan), salt)
+
+
 def plan_hash(plan_text: str, salt: str) -> str:
     """
-    Compute a hash of the plan
+    Compute a hash of the plan text.
 
-    This currently uses the plan text output.
-    TODO: Change to use the plan json output
+    Legacy function retained for backward compatibility with PR comments that were created
+    before JSON-based hashing was introduced. Use plan_json_hash where possible.
     """
 
-    debug(f'Hashing with salt {salt}')
+    debug(f'Hashing plan text with salt {salt}')
 
     plan = remove_warnings(remove_unchanged_attributes(plan_text))
 


### PR DESCRIPTION
Fixes #196.

## What changed

Switch plan comparison hashing from the human-readable `terraform plan` text output to the machine-readable `terraform show -json` output.

### `image/src/github_pr_comment/hash.py`
- Added `plan_json_hash(json_plan_path, salt)`: reads the full JSON plan, removes only the `timestamp` field (the single volatile field that changes on every run but carries no information about what will change), canonicalises with `canonicaljson` for key-order determinism, and hashes.
- `plan_hash()` (text-based) is retained unchanged as a backward-compatibility fallback.

### `image/src/github_pr_comment/comment.py`
- Registered the new `plan_json_hash` PR comment header field alongside the existing `plan_hash`.

### `image/src/github_pr_comment/__main__.py`
- `_json_plan_path()`: constructs the path to `plan.json` from the `GITHUB_WORKSPACE` and `WORKSPACE_TMP_DIR` env vars already exported by `actions.sh`, returning `None` if the file doesn't exist.
- When **storing** a plan comment: writes `plan_json_hash` when `plan.json` is available, and always writes the legacy `plan_hash` alongside it so older versions of the apply action can still verify.
- When **verifying** at apply time: `is_approved()` prefers `plan_json_hash` → falls back to `plan_hash` → falls back to direct text comparison.

## Why

Terraform's text output is non-deterministic across runs even when the planned changes are identical. Cosmetic differences (ordering, whitespace, provider-injected warnings) were causing spurious "plan changed" failures at apply time and blocking deployments. The JSON output is stable for the same intended changes.

## Backward compatibility

Fully preserved. PR comments created before this change carry `plan_hash` but no `plan_json_hash`. The three-level fallback in `is_approved()` handles them transparently — no re-plan required for in-flight PRs.

## When JSON is unavailable

JSON plan output is not produced when using remote/cloud backends that do not support saving plan files (`PLAN_OUT=""`). In that case `_json_plan_path()` returns `None`, `plan_json_hash` is not stored, and the existing text-based path is used unchanged.