### PR TITLE
Fix reading of old comments using variablised backend config

### DIFF
--- a/.github/workflows/test-apply.yaml
+++ b/.github/workflows/test-apply.yaml
@@ -1262,6 +1262,25 @@ jobs:
           backend_config_file: tests/workflows/test-apply/partial_backend/backend_config
           backend_config: key=${{ github.run_id }}${{ github.run_attempt }}
 
+      - name: Check the comment was updated
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BACKEND_KEY: key=${{ github.run_id }}${{ github.run_attempt }}
+        run: |
+          BODY=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" --paginate --jq '.[]' \
+            | jq -r -s --arg key "$BACKEND_KEY" '[.[] | select(.body | (contains("partial_backend") and contains($key)))] | last | .body // empty')
+
+          if [[ -z "$BODY" ]]; then
+            echo "::error:: The PR comment created by the old action version was not found"
+            exit 1
+          fi
+
+          if [[ "$BODY" != *"Plan applied in"* ]]; then
+            echo "::error:: The PR comment created by the old action version was not updated by terraform-apply"
+            exit 1
+          fi
+
   destroy_mode:
     runs-on: ubuntu-24.04
     name: Generate and apply a destroy mode plan

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,5 +1,5 @@
 # hadolint ignore=DL3007
-FROM danielflook/terraform-github-actions-base:trixie
+FROM danielflook/terraform-github-actions-base:latest
 
 ARG TARGETARCH
 

--- a/image/src/github_pr_comment/__main__.py
+++ b/image/src/github_pr_comment/__main__.py
@@ -16,7 +16,7 @@ from github_actions.debug import debug
 from github_actions.env import GithubEnv
 from github_actions.find_pr import find_pr, WorkflowException
 from github_actions.inputs import PlanPrInputs
-from github_pr_comment.backend_config import complete_config, legacy_complete_config, legacy_partial_config, COMPLETE_FINGERPRINT_SINCE_VERSION, FIXED_FINGERPRINT_SINCE_VERSION
+from github_pr_comment.backend_config import complete_config, legacy_complete_config, legacy_partial_config, COMPLETE_FINGERPRINT_SINCE_VERSION, FIXED_FINGERPRINT_SINCE_VERSION, INITIALISED_FINGERPRINT_SINCE_VERSION
 from github_pr_comment.backend_fingerprint import fingerprint
 from github_pr_comment.cmp import plan_cmp, remove_warnings, remove_unchanged_attributes
 from github_pr_comment.comment import find_comment, BackupHeaders, TerraformComment, update_comment, serialize, deserialize, hide_comment
@@ -367,7 +367,10 @@ def get_backend_fingerprints(action_inputs: PlanPrInputs, module: TerraformModul
 
     Earlier fingerprints:
     legacy_complete_config, before the backend_config input parsing was fixed.
-    legacy_partial_config, used by versions before that, which also didn't read backend config files.
+    legacy_complete_config without the initialised config, used by versions before the
+    fingerprint included values from the initialised backend.
+    legacy_partial_config without the initialised config, used by versions before that,
+    which also didn't read backend config files.
 
     Where the fingerprints for different eras are identical their version ranges are combined.
     The eras are contiguous, so the combined range is simply the widest bounds.
@@ -377,12 +380,13 @@ def get_backend_fingerprints(action_inputs: PlanPrInputs, module: TerraformModul
     backend_fingerprint = fingerprint(backend_type, backend_config, os.environ)
 
     backup_fingerprints: List[Tuple[bytes, Optional[str], Optional[str]]] = []
-    for fallback_config, min_version, max_version in (
-        (legacy_complete_config, COMPLETE_FINGERPRINT_SINCE_VERSION, FIXED_FINGERPRINT_SINCE_VERSION),
-        (legacy_partial_config, None, COMPLETE_FINGERPRINT_SINCE_VERSION),
+    for fallback_config, include_initialised, min_version, max_version in (
+        (legacy_complete_config, True, INITIALISED_FINGERPRINT_SINCE_VERSION, FIXED_FINGERPRINT_SINCE_VERSION),
+        (legacy_complete_config, False, COMPLETE_FINGERPRINT_SINCE_VERSION, INITIALISED_FINGERPRINT_SINCE_VERSION),
+        (legacy_partial_config, False, None, COMPLETE_FINGERPRINT_SINCE_VERSION),
     ):
         fallback_backend_type, fallback_backend_config = fallback_config(action_inputs, module)
-        backup_fingerprint = fingerprint(fallback_backend_type, fallback_backend_config, os.environ)
+        backup_fingerprint = fingerprint(fallback_backend_type, fallback_backend_config, os.environ, include_initialised_config=include_initialised)
 
         if backup_fingerprint == backend_fingerprint:
             # Comments with this fingerprint are matched by the primary headers

--- a/image/src/github_pr_comment/backend_config.py
+++ b/image/src/github_pr_comment/backend_config.py
@@ -57,6 +57,10 @@ def read_backend_config_input(init_inputs: InitInputs) -> BackendConfig:
 # versions. Versions 1.32.0-1.32.1 stamped comments with '1.31.1', which is fine for this purpose.
 COMPLETE_FINGERPRINT_SINCE_VERSION = '1.31.1'
 
+# The first version that overlays the fingerprint with values from the initialised backend,
+# read from the terraform data dir. Versions before this fingerprinted only the configured values.
+INITIALISED_FINGERPRINT_SINCE_VERSION = '1.49.0'
+
 # The first version that parses the backend_config input by splitting key=value pairs on the
 # first '=' instead of the last. Comments created by this version or later never carry legacy
 # fingerprints, so are never matched against them.

--- a/image/src/github_pr_comment/backend_fingerprint.py
+++ b/image/src/github_pr_comment/backend_fingerprint.py
@@ -175,7 +175,14 @@ def fingerprint_local(backend_config: BackendConfig, env) -> dict[str, str]:
     return fingerprint_inputs
 
 
-def fingerprint(backend_type: BackendType, backend_config: BackendConfig, env) -> bytes:
+def fingerprint(backend_type: BackendType, backend_config: BackendConfig, env, include_initialised_config: bool = True) -> bytes:
+    """
+    The fingerprint for a backend config.
+
+    With include_initialised_config=False, values from the initialised backend are not included,
+    as computed by versions before INITIALISED_FINGERPRINT_SINCE_VERSION.
+    """
+
     backends = {
         'remote': fingerprint_remote,
         'artifactory': fingerprint_artifactory,
@@ -198,7 +205,9 @@ def fingerprint(backend_type: BackendType, backend_config: BackendConfig, env) -
     }
 
     fingerprint_inputs = backends.get(backend_type, lambda c, e: c)(backend_config, env)
-    fingerprint_inputs = initialised_backend_config(backend_type, fingerprint_inputs)
+
+    if include_initialised_config:
+        fingerprint_inputs = initialised_backend_config(backend_type, fingerprint_inputs)
 
     debug(f'Backend fingerprint includes {fingerprint_inputs.keys()}')
 

--- a/tests/github_pr_comment/test_find_comment.py
+++ b/tests/github_pr_comment/test_find_comment.py
@@ -1,5 +1,7 @@
+import json
+
 from github_pr_comment.__main__ import get_backend_fingerprints
-from github_pr_comment.backend_config import complete_config, legacy_complete_config, legacy_partial_config, COMPLETE_FINGERPRINT_SINCE_VERSION, FIXED_FINGERPRINT_SINCE_VERSION
+from github_pr_comment.backend_config import complete_config, legacy_complete_config, legacy_partial_config, COMPLETE_FINGERPRINT_SINCE_VERSION, FIXED_FINGERPRINT_SINCE_VERSION, INITIALISED_FINGERPRINT_SINCE_VERSION
 from github_pr_comment.backend_fingerprint import fingerprint
 from github_pr_comment.comment import find_comment, matching_headers, BackupHeaders, TerraformComment, _to_api_payload, _format_comment_header, _parse_comment_header
 from github_pr_comment.hash import comment_hash
@@ -277,6 +279,62 @@ def test_find_comment_null_header_values_are_scrubbed(monkeypatch, tmp_path):
     assert found.comment_url == COMMENT_URL
     assert 'closed' not in found.headers
     assert 'label' not in found.headers
+
+
+def test_find_comment_created_before_initialised_fingerprints(monkeypatch, tmp_path):
+    """A comment from a version that didn't include the initialised config in the fingerprint
+    must still be matched once the backend has been initialised.
+
+    e.g. a partial s3 backend where the bucket is only known once initialised:
+    old versions fingerprinted an empty bucket.
+    """
+
+    monkeypatch.setenv('TF_DATA_DIR', str(tmp_path))
+    monkeypatch.delenv('AWS_S3_ENDPOINT', raising=False)
+
+    module = loads('''
+terraform {
+  backend s3 {}
+}
+    ''')
+
+    inputs = {
+        'INPUT_BACKEND_CONFIG_FILE': '',
+        'INPUT_BACKEND_CONFIG': 'key=test-state-key'
+    }
+
+    # The fingerprint of the comment, as created by a version before the
+    # initialised config was included
+    backend_type, backend_config = legacy_partial_config(inputs, module)
+    old_fingerprint = fingerprint(backend_type, backend_config, {}, include_initialised_config=False)
+
+    # The backend is now initialised, with the complete config
+    (tmp_path / 'terraform.tfstate').write_text(json.dumps({
+        'backend': {
+            'type': 's3',
+            'config': {'bucket': 'test-bucket', 'key': 'test-state-key'}
+        }
+    }))
+
+    primary, backups = get_backend_fingerprints(inputs, module)
+    assert primary != old_fingerprint
+
+    # The eras without the initialised config are identical here, and merge
+    assert backups == [(old_fingerprint, None, INITIALISED_FINGERPRINT_SINCE_VERSION)]
+
+    old_comment = make_comment(comment_hash(old_fingerprint, PR_URL))
+
+    headers = {'workspace': 'default', 'closed': None, 'label': None, 'backend': comment_hash(primary, PR_URL)}
+    backup_headers = [
+        BackupHeaders({'workspace': 'default', 'closed': None, 'label': None, 'backend': comment_hash(fp, PR_URL)}, min_version, max_version)
+        for fp, min_version, max_version in backups
+    ]
+
+    github = StubGithub([comment_payload(old_comment)])
+    found = find_comment(github, ISSUE_URL, 'test-user', headers, backup_headers, 'legacy description')
+
+    assert found.comment_url == COMMENT_URL
+    assert found.headers['backend'] == comment_hash(primary, PR_URL)
 
 
 def test_find_comment_ignores_other_backends(monkeypatch, tmp_path):


### PR DESCRIPTION
The fingerprint should include the completed config in those cases - old comments didn't, so we need to account for that.