### PR TITLE
Add to_forget and to_invoke outputs

### DIFF
--- a/.github/workflows/test-apply.yaml
+++ b/.github/workflows/test-apply.yaml
@@ -1467,18 +1467,22 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Plan using default ephemeral value
+      - name: Plan with required ephemeral variable
         uses: ./terraform-plan
         with:
           label: test-apply ephemeral
           path: tests/workflows/test-apply/ephemeral
+          variables: |
+            secret = "super-secret"
 
-      - name: Apply using default ephemeral value
+      - name: Apply with required ephemeral variable
         uses: ./terraform-apply
         id: apply
         with:
           label: test-apply ephemeral
           path: tests/workflows/test-apply/ephemeral
+          variables: |
+            secret = "super-secret"
 
       - name: Verify outputs
         env:
@@ -1499,6 +1503,7 @@ jobs:
           variables: |
             region = "eu-west-1"
             mv = "hello"
+            secret = "super-secret"
 
       - name: Apply using explicit ephemeral value
         uses: ./terraform-apply
@@ -1509,6 +1514,7 @@ jobs:
           variables: |
             region = "eu-west-1"
             mv = "hello"
+            secret = "super-secret"
 
       - name: Verify outputs
         env:
@@ -1529,6 +1535,7 @@ jobs:
           variables: |
             region = "eu-west-2"
             mv = "goodbye"
+            secret = "super-secret"
 
       - name: Apply using mismatched explicit non-ephemeral value
         uses: ./terraform-apply
@@ -1540,6 +1547,113 @@ jobs:
           variables: |
             region = "eu-west-2"
             mv = "mismatch"
+            secret = "super-secret"
+
+      - name: Check failed to apply
+        env:
+          OUTCOME: ${{ steps.apply3.outcome }}
+        run: |
+          if [[ "$OUTCOME" != "failure" ]]; then
+            echo "Apply did not fail correctly"
+            exit 1
+          fi
+
+  ephemeral_opentofu:
+    runs-on: ubuntu-24.04
+    name: Apply a plan with ephemeral variables using OpenTofu
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      OPENTOFU_VERSION: "1.11.12"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Plan with required ephemeral variable
+        uses: ./tofu-plan
+        with:
+          label: test-apply ephemeral tofu
+          path: tests/workflows/test-apply/ephemeral
+          variables: |
+            secret = "super-secret"
+
+      - name: Apply with required ephemeral variable
+        uses: ./tofu-apply
+        id: apply
+        with:
+          label: test-apply ephemeral tofu
+          path: tests/workflows/test-apply/ephemeral
+          variables: |
+            secret = "super-secret"
+
+      - name: Verify outputs
+        env:
+          OUTPUT_STRING: ${{ steps.apply.outputs.v }}
+        run: |
+          if [[ "$OUTPUT_STRING" != "non-ephemeral" ]]; then
+            echo "::error:: output v not set correctly"
+            exit 1
+          fi
+
+      ##
+
+      - name: Plan using explicit ephemeral value
+        uses: ./tofu-plan
+        with:
+          label: test-apply ephemeral tofu 2
+          path: tests/workflows/test-apply/ephemeral
+          variables: |
+            region = "eu-west-1"
+            mv = "hello"
+            secret = "super-secret"
+
+      - name: Apply using explicit ephemeral value
+        uses: ./tofu-apply
+        id: apply2
+        with:
+          label: test-apply ephemeral tofu 2
+          path: tests/workflows/test-apply/ephemeral
+          variables: |
+            region = "eu-west-1"
+            mv = "hello"
+            secret = "super-secret"
+
+      - name: Verify outputs
+        env:
+          OUTPUT_STRING: ${{ steps.apply2.outputs.v }}
+        run: |
+          if [[ "$OUTPUT_STRING" != "hello" ]]; then
+            echo "::error:: output v not set correctly"
+            exit 1
+          fi
+
+      ##
+
+      - name: Plan using explicit non-ephemeral value
+        uses: ./tofu-plan
+        with:
+          label: test-apply ephemeral tofu 3
+          path: tests/workflows/test-apply/ephemeral
+          variables: |
+            region = "eu-west-2"
+            mv = "goodbye"
+            secret = "super-secret"
+
+      - name: Apply using mismatched explicit non-ephemeral value
+        uses: ./tofu-apply
+        continue-on-error: true
+        id: apply3
+        with:
+          label: test-apply ephemeral tofu 3
+          path: tests/workflows/test-apply/ephemeral
+          variables: |
+            region = "eu-west-2"
+            mv = "mismatch"
+            secret = "super-secret"
 
       - name: Check failed to apply
         env:

--- a/docs-gen/action.py
+++ b/docs-gen/action.py
@@ -189,6 +189,7 @@ class Action:
             "text_plan_path",
             "junit_xml_path",
             "to_add",
+            "to_invoke",
             "failure_reason",
             "lock_info",
             "run_id",

--- a/docs-gen/actions/plan.py
+++ b/docs-gen/actions/plan.py
@@ -30,6 +30,7 @@ from outputs.plan_path import plan_path
 from outputs.run_id import run_id
 from outputs.text_plan_path import text_plan_path
 from outputs.to_add import to_add
+from outputs.to_invoke import to_invoke
 
 plan = Action(
     'plan',
@@ -70,6 +71,7 @@ The [dflook/$ToolName-apply](https://github.com/dflook/terraform-github-actions/
         json_plan_path,
         text_plan_path,
         to_add,
+        to_invoke,
         run_id
     ],
     environment_variables=[

--- a/docs-gen/outputs/to_add.py
+++ b/docs-gen/outputs/to_add.py
@@ -7,5 +7,5 @@ to_add = Output(
 The number of resources that would be affected by each type of operation.
 ''',
     meta_description='The number of resources that would be affected by this operation.',
-    aliases=['to_change', 'to_destroy', 'to_move', 'to_import']
+    aliases=['to_change', 'to_destroy', 'to_move', 'to_import', 'to_forget']
 )

--- a/docs-gen/outputs/to_invoke.py
+++ b/docs-gen/outputs/to_invoke.py
@@ -1,0 +1,13 @@
+from action import Output, Terraform
+
+to_invoke = Output(
+    name='to_invoke',
+    type='number',
+    description='''
+The number of actions that would be invoked by the plan, using `action_trigger` lifecycle events.
+
+Requires Terraform 1.14+.
+''',
+    meta_description='The number of actions that would be invoked by this operation.',
+    available_in=[Terraform]
+)

--- a/image/src/github_pr_comment/__main__.py
+++ b/image/src/github_pr_comment/__main__.py
@@ -200,6 +200,7 @@ def create_summary(plan: Plan, changes: bool=True) -> Optional[str]:
     summary = None
 
     to_move = 0
+    to_forget = 0
 
     for line in plan.splitlines():
         if line.startswith('No changes') or line.startswith('Error'):
@@ -208,11 +209,21 @@ def create_summary(plan: Plan, changes: bool=True) -> Optional[str]:
         if re.match(r'  # \S+ has moved to \S+$', line):
             to_move += 1
 
+        # Terraform doesn't include forgotten resources in the summary line, so count them
+        if re.match(r' # \S+ will no longer be managed by Terraform, but will not be destroyed$', line):
+            to_forget += 1
+
+        if re.match(r'  # \S+ will be removed from the OpenTofu state but will not be destroyed$', line):
+            to_forget += 1
+
         if line.startswith('Plan:'):
             summary = line
 
             if to_move and 'move' not in summary:
                 summary = summary.rstrip('.') + f', {to_move} to move.'
+
+            if to_forget and 'forget' not in summary:
+                summary = summary.rstrip('.') + f', {to_forget} to forget.'
 
         if line.startswith('Changes to Outputs'):
             if summary:

--- a/image/src/plan_summary/__main__.py
+++ b/image/src/plan_summary/__main__.py
@@ -5,6 +5,10 @@ Creates the outputs:
 - to_add
 - to_change
 - to_destroy
+- to_move
+- to_import
+- to_forget
+- to_invoke
 
 Usage:
     plan_summary
@@ -22,14 +26,24 @@ def summary(plan: str) -> dict[str, int]:
         'change': 0,
         'destroy': 0,
         'move': None,
-        'import': 0
+        'import': 0,
+        'forget': None,
+        'invoke': 0
     }
 
     to_move = 0
+    to_forget = 0
 
     for line in plan.splitlines():
         if re.match(r'  # \S+ has moved to \S+$', line):
             to_move += 1
+
+        # Terraform doesn't include forgotten resources in the summary line, so count them
+        if re.match(r' # \S+ will no longer be managed by Terraform, but will not be destroyed$', line):
+            to_forget += 1
+
+        if re.match(r'  # \S+ will be removed from the OpenTofu state but will not be destroyed$', line):
+            to_forget += 1
 
         if not line.startswith('Plan:'):
             continue
@@ -39,6 +53,9 @@ def summary(plan: str) -> dict[str, int]:
 
     if operations['move'] is None:
         operations['move'] = to_move
+
+    if operations['forget'] is None:
+        operations['forget'] = to_forget
 
     return operations
 

--- a/terraform-plan/README.md
+++ b/terraform-plan/README.md
@@ -210,8 +210,17 @@ The [dflook/terraform-apply](https://github.com/dflook/terraform-github-actions/
 * `to_destroy`
 * `to_move`
 * `to_import`
+* `to_forget`
 
   The number of resources that would be affected by each type of operation.
+
+  - Type: number
+
+* `to_invoke`
+
+  The number of actions that would be invoked by the plan, using `action_trigger` lifecycle events.
+
+  Requires Terraform 1.14+.
 
   - Type: number
 

--- a/terraform-plan/action.yaml
+++ b/terraform-plan/action.yaml
@@ -110,6 +110,10 @@ outputs:
     description: The number of resources that would be affected by this operation.
   to_import:
     description: The number of resources that would be affected by this operation.
+  to_forget:
+    description: The number of resources that would be affected by this operation.
+  to_invoke:
+    description: The number of actions that would be invoked by this operation.
   run_id:
     description: If the root module uses the `remote` or `cloud` backend in remote execution mode, this output will be set to the remote run id.
 

--- a/tests/github_pr_comment/test_summary.py
+++ b/tests/github_pr_comment/test_summary.py
@@ -169,17 +169,54 @@ def test_summary_move_only():
         length      = 8
         # (8 unchanged attributes hidden)
     }
-    
+
   # random_string.blah_string has moved to random_string.my_string2
     resource "random_string" "my_string2" {
         id          = "Iyh3jLKc"
         length      = 8
         # (8 unchanged attributes hidden)
-    }    
+    }
 
 Plan: 0 to add, 0 to change, 0 to destroy.
 """
 
     expected = "Plan: 0 to add, 0 to change, 0 to destroy, 2 to move."
+
+    assert create_summary(plan) == expected
+
+def test_summary_forget_only():
+    # Terraform does not include forgotten resources in the summary line,
+    # so they are counted from the plan text
+    plan = """Terraform will perform the following actions:
+
+ # terraform_data.x will no longer be managed by Terraform, but will not be destroyed
+ # (destroy = false is set in the configuration)
+ . resource "terraform_data" "x" {
+        id     = "c5464233-23a4-f524-e5c8-d28838eb0687"
+        # (2 unchanged attributes hidden)
+    }
+
+Plan: 0 to add, 0 to change, 0 to destroy.
+"""
+
+    expected = "Plan: 0 to add, 0 to change, 0 to destroy, 1 to forget."
+
+    assert create_summary(plan) == expected
+
+def test_summary_forget_opentofu():
+    # OpenTofu includes forgotten resources in the summary line, which is used as-is
+    plan = """OpenTofu will perform the following actions:
+
+  # terraform_data.x will be removed from the OpenTofu state but will not be destroyed
+  . resource "terraform_data" "x" {
+    id     = "c5464233-23a4-f524-e5c8-d28838eb0687"
+    input  = "hello"
+    output = "hello"
+}
+
+Plan: 0 to add, 0 to change, 0 to destroy, 1 to forget.
+"""
+
+    expected = "Plan: 0 to add, 0 to change, 0 to destroy, 1 to forget."
 
     assert create_summary(plan) == expected

--- a/tests/test_action_summary.py
+++ b/tests/test_action_summary.py
@@ -28,7 +28,9 @@ Plan: 1 to add, 0 to change, 0 to destroy.
         'change': 0,
         'destroy': 0,
         'move': 0,
-        'import': 0
+        'import': 0,
+        'forget': 0,
+        'invoke': 0
     }
 
 def test_summary_import():
@@ -58,7 +60,9 @@ Plan: 5 to import, 1 to add, 0 to change, 0 to destroy.
         'change': 0,
         'destroy': 0,
         'move': 0,
-        'import': 5
+        'import': 5,
+        'forget': 0,
+        'invoke': 0
     }
 
 def test_summary_remove():
@@ -89,6 +93,8 @@ Plan: 5 to import, 1 to add, 3 to remove, 0 to change, 0 to destroy.
         'destroy': 0,
         'move': 0,
         'import': 5,
+        'forget': 0,
+        'invoke': 0,
         'remove': 3
     }
 
@@ -118,6 +124,102 @@ Plan: 4 to add, 8 to change, 1 to destroy.
         'change': 8,
         'destroy': 1,
         'move': 2,
-        'import': 0
+        'import': 0,
+        'forget': 0,
+        'invoke': 0
+    }
+
+def test_summary_forget():
+    plan = '''OpenTofu used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  . forget
+
+OpenTofu will perform the following actions:
+
+  # terraform_data.x will be removed from the OpenTofu state but will not be destroyed
+  . resource "terraform_data" "x" {
+    id     = "c5464233-23a4-f524-e5c8-d28838eb0687"
+    input  = "hello"
+    output = "hello"
+}
+
+Plan: 0 to add, 0 to change, 0 to destroy, 1 to forget.
+'''
+
+    assert summary(plan) == {
+        'add': 0,
+        'change': 0,
+        'destroy': 0,
+        'move': 0,
+        'import': 0,
+        'forget': 1,
+        'invoke': 0
+    }
+
+def test_summary_forget_terraform():
+    # Terraform does not include forgotten resources in the summary line,
+    # so they are counted from the plan text
+    plan = '''Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+
+Terraform will perform the following actions:
+
+ # terraform_data.x will no longer be managed by Terraform, but will not be destroyed
+ # (destroy = false is set in the configuration)
+ . resource "terraform_data" "x" {
+        id     = "c5464233-23a4-f524-e5c8-d28838eb0687"
+        # (2 unchanged attributes hidden)
+    }
+
+ # terraform_data.y will no longer be managed by Terraform, but will not be destroyed
+ # (destroy = false is set in the configuration)
+ . resource "terraform_data" "y" {
+        id     = "0e352811-a659-4933-af31-7e39d3fda849"
+        # (2 unchanged attributes hidden)
+    }
+
+Plan: 0 to add, 0 to change, 0 to destroy.
+
+Warning: Some objects will no longer be managed by Terraform
+
+If you apply this plan, Terraform will discard its tracking information for
+the following objects, but it will not delete them:
+ - terraform_data.x
+ - terraform_data.y
+'''
+
+    assert summary(plan) == {
+        'add': 0,
+        'change': 0,
+        'destroy': 0,
+        'move': 0,
+        'import': 0,
+        'forget': 2,
+        'invoke': 0
+    }
+
+def test_summary_invoke():
+    plan = '''Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # terraform_data.x will be created
+  + resource "terraform_data" "x" {
+      + id = (known after apply)
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy. Actions: 2 to invoke.
+'''
+
+    assert summary(plan) == {
+        'add': 1,
+        'change': 0,
+        'destroy': 0,
+        'move': 0,
+        'import': 0,
+        'forget': 0,
+        'invoke': 2
     }
 

--- a/tests/workflows/test-apply/ephemeral/main.tf
+++ b/tests/workflows/test-apply/ephemeral/main.tf
@@ -8,8 +8,20 @@ variable "mv" {
   default = "non-ephemeral"
 }
 
+variable "secret" {
+  type = string
+  ephemeral = true
+}
+
+variable "session_tag" {
+  type = string
+  ephemeral = true
+  default = "ephemeral-default"
+}
+
 provider "aws" {
   region = var.region
+  token = var.secret
 }
 
 output "v" {

--- a/tofu-plan/README.md
+++ b/tofu-plan/README.md
@@ -227,6 +227,7 @@ The [dflook/tofu-apply](https://github.com/dflook/terraform-github-actions/tree/
 * `to_destroy`
 * `to_move`
 * `to_import`
+* `to_forget`
 
   The number of resources that would be affected by each type of operation.
 

--- a/tofu-plan/action.yaml
+++ b/tofu-plan/action.yaml
@@ -118,6 +118,8 @@ outputs:
     description: The number of resources that would be affected by this operation.
   to_import:
     description: The number of resources that would be affected by this operation.
+  to_forget:
+    description: The number of resources that would be affected by this operation.
   run_id:
     description: If the root module uses the `remote` or `cloud` backend in remote execution mode, this output will be set to the remote run id.
 


### PR DESCRIPTION
to_forget was set correctly on OpenTofu if there was any forgotten resources, but was not previously documented. It now also works for Terraform, and also sets the output to '0' if there are none instead of omitting the output.

to_invoke also mostly worked for Terraform, but is now documented and defaults to '0' if there were none.